### PR TITLE
Fix documentation build

### DIFF
--- a/CodeJamDoc.sln
+++ b/CodeJamDoc.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeJam.Main", "Main\src\CodeJam.Main.csproj", "{2F2046CC-FB47-4318-B335-5A82B04B6C40}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeJam.Blocks", "Blocks\src\CodeJam.Blocks.csproj", "{0DFF0859-2400-4487-83AD-0ED10203D6D9}"
+EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "CodeJamDoc", "CodeJamDoc.shfbproj", "{383368D3-567C-4BF6-96D4-7A292DA5D486}"
 EndProject
 Global
@@ -17,6 +19,10 @@ Global
 		{2F2046CC-FB47-4318-B335-5A82B04B6C40}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F2046CC-FB47-4318-B335-5A82B04B6C40}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F2046CC-FB47-4318-B335-5A82B04B6C40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DFF0859-2400-4487-83AD-0ED10203D6D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DFF0859-2400-4487-83AD-0ED10203D6D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DFF0859-2400-4487-83AD-0ED10203D6D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DFF0859-2400-4487-83AD-0ED10203D6D9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{383368D3-567C-4BF6-96D4-7A292DA5D486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{383368D3-567C-4BF6-96D4-7A292DA5D486}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{383368D3-567C-4BF6-96D4-7A292DA5D486}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/PerfTests/CodeJam.PerfTests.shfbproj
+++ b/PerfTests/CodeJam.PerfTests.shfbproj
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{0c2b28b1-e46a-4ef6-b0cc-f007f289190e}</ProjectGuid>
-    <SHFBSchemaVersion>2015.6.5.0</SHFBSchemaVersion>
+    <SHFBSchemaVersion>2017.9.26.0</SHFBSchemaVersion>
     <!-- AssemblyName, Name, and RootNamespace are not used by SHFB but Visual Studio adds them anyway -->
     <AssemblyName>Documentation</AssemblyName>
     <RootNamespace>Documentation</RootNamespace>

--- a/appveyor.doc.yml
+++ b/appveyor.doc.yml
@@ -3,12 +3,14 @@ image: Visual Studio 2017
 configuration: Debug
 clone_folder: c:\projects\codejam
 environment:
-  SHFBROOT: C:\EWSoftware.SHFB.2015.10.10.0\tools\
+  SHFBROOT: C:\EWSoftware.SHFB.2018.7.8.1\tools\
 install:
 - cmd: >-
-    nuget install EWSoftware.SHFB -o c:\ -Version 2015.10.10
+    nuget install EWSoftware.SHFB -o c:\ -Version 2018.7.8.1
 
     nuget install EWSoftware.SHFB.NETFramework -o c:\projects\codejam
+
+    xcopy /E /S C:\EWSoftware.SHFB.2018.7.8.1 C:\EWSoftware.SHFB.2015.10.10.0\
 before_build:
 - cmd: nuget restore CodeJam.sln
 build:


### PR DESCRIPTION
Fix #57.
1. Update SHFB package.
2. Update schema version in CodeJam.PerfTests.shfbproj.
3. Add CodeJam.Blocks to documentation build.
4. Copy package to old folder 2015.6.5.0. For some reason the new folder is not used.
