### PR TITLE
Assertions revisited

### DIFF
--- a/CodeJam.Main.Tests/Assertions/CodeTests.cs
+++ b/CodeJam.Main.Tests/Assertions/CodeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -31,7 +32,7 @@ namespace CodeJam.Assertions
 				ts.Switch.Level = SourceLevels.All;
 				ts.Listeners.Add(listener);
 
-				var ex = Assert.Throws<ArgumentNullException>(() => Code.NotNull<object>(null, "arg00"));
+				var ex = Assert.Throws<ArgumentNullException>(() => Code.NotNull(default(object), "arg00"));
 				Assert.That(ex.Message, Does.Contain("arg00"));
 
 				var logOutput = logWriter.ToString();
@@ -48,20 +49,33 @@ namespace CodeJam.Assertions
 				ts.Switch.Level = logLevel;
 			}
 		}
+
 		[Test]
 		public void TestNotNull()
 		{
-			var ex = Assert.Throws<ArgumentNullException>(() => Code.NotNull<object>(null, "arg00"));
+			var ex = Assert.Throws<ArgumentNullException>(() => Code.NotNull(default(object), "arg00"));
 			Assert.That(ex.Message, Does.Contain("arg00"));
 
 			Assert.DoesNotThrow(() => Code.NotNull<object>("Hello!", "arg00"));
 		}
 
 		[Test]
+		public void TestGenericNotNull()
+		{
+			var ex = Assert.Throws<ArgumentNullException>(() => Code.GenericNotNull(default(object), "arg00"));
+			Assert.That(ex.Message, Does.Contain("arg00"));
+
+			Assert.DoesNotThrow(() => Code.GenericNotNull<object>("Hello!", "arg00"));
+
+			// They made me to write this
+			Assert.DoesNotThrow(() => Code.GenericNotNull(default(int), "arg00"));
+		}
+
+		[Test]
 		public void TestDebugNotNull()
 		{
 #if DEBUG
-			var ex = Assert.Throws<ArgumentNullException>(() => DebugCode.NotNull<object>(null, "arg00"));
+			var ex = Assert.Throws<ArgumentNullException>(() => DebugCode.NotNull(default(object), "arg00"));
 			Assert.That(ex.Message, Does.Contain("arg00"));
 #else
 			// ReSharper disable once InvocationIsSkipped
@@ -73,15 +87,35 @@ namespace CodeJam.Assertions
 		}
 
 		[Test]
-		public void TestNotNullNorEmpty()
+		public void TestStringNotNullNorEmpty()
 		{
-			Assert.Throws<ArgumentException>(() => Code.NotNullNorEmpty(null, "arg00"));
+			Assert.Throws<ArgumentException>(() => Code.NotNullNorEmpty(default, "arg00"));
 			var ex = Assert.Throws<ArgumentException>(() => Code.NotNullNorEmpty("", "arg00"));
 			Assert.That(ex.Message, Does.Contain("arg00"));
 			Assert.That(ex.Message, Does.Contain("String 'arg00' should be neither null nor empty"));
 
 			Assert.DoesNotThrow(() => Code.NotNullNorEmpty(" ", "arg00"));
 			Assert.DoesNotThrow(() => Code.NotNullNorEmpty("Hello!", "arg00"));
+		}
+
+		[Test]
+		public void TestCollectionNotNullNorEmpty()
+		{
+			var empty = new HashSet<int>();
+#if LESSTHAN_NET45
+			var nonEmpty = (IList<int>)new ListEx<int> { 1 };
+#else
+			var nonEmpty = (IList<int>)new List<int> { 1 };
+#endif
+			var nonEmpty2 = (IReadOnlyCollection<int>)nonEmpty;
+
+			Assert.Throws<ArgumentNullException>(() => Code.NotNullNorEmpty(default(IList<int>), "arg00"));
+			var ex = Assert.Throws<ArgumentException>(() => Code.NotNullNorEmpty(empty, "arg00"));
+			Assert.That(ex.Message, Does.Contain("arg00"));
+			Assert.That(ex.Message, Does.Contain("Collection 'arg00' must not be empty"));
+
+			Assert.DoesNotThrow(() => Code.NotNullNorEmpty(nonEmpty, "arg00"));
+			Assert.DoesNotThrow(() => Code.NotNullNorEmpty(nonEmpty2, "arg00"));
 		}
 
 		[Test]

--- a/CodeJam.Main.Tests/IO/PathHelpersTests.cs
+++ b/CodeJam.Main.Tests/IO/PathHelpersTests.cs
@@ -17,12 +17,23 @@ namespace CodeJam.IO
 			ValidRelativePath,
 			ValidAbsoluteContainerPath,
 			ValidRelativeContainerPath,
-			ValidSimpleName
+			ValidFileName
 		}
 
 		[TestCase("", PathKind.Throws)]
 		[TestCase(null, PathKind.Throws)]
-		[TestCase(@"a", PathKind.ValidSimpleName)]
+		[TestCase(@"a", PathKind.ValidFileName)]
+		[TestCase(@"a ", PathKind.ValidFileName)]
+		[TestCase(@"a    ", PathKind.ValidFileName)]
+		[TestCase(@"a\t", PathKind.ValidRelativePath)]
+		[TestCase(@"a...", PathKind.ValidFileName)]
+		[TestCase(@"a.", PathKind.ValidFileName)]
+
+		[TestCase(@" a", PathKind.ValidFileName)]
+		[TestCase(@"    a", PathKind.ValidFileName)]
+		[TestCase(@"\ta", PathKind.Invalid)]
+		[TestCase(@"...a", PathKind.ValidFileName)]
+
 		[TestCase(@"a\b", PathKind.ValidRelativePath)]
 		[TestCase(@"a\b\", PathKind.ValidRelativeContainerPath)]
 		[TestCase(@"a/b", PathKind.ValidRelativePath)]
@@ -40,8 +51,8 @@ namespace CodeJam.IO
 		[TestCase(@"\\a\b\", PathKind.ValidAbsoluteContainerPath)]
 		[TestCase(@"\\a\\b\", PathKind.Invalid)]
 		[TestCase(@"\\a\b/", PathKind.Invalid)]
-		[TestCase(@".a", PathKind.ValidSimpleName)]
-		[TestCase(@".a.b", PathKind.ValidSimpleName)]
+		[TestCase(@".a", PathKind.ValidFileName)]
+		[TestCase(@".a.b", PathKind.ValidFileName)]
 		[TestCase(@"..a\", PathKind.ValidRelativeContainerPath)]
 		[TestCase(@"..a.b\", PathKind.ValidRelativeContainerPath)]
 		[TestCase(@"..a..\", PathKind.ValidRelativeContainerPath)]
@@ -67,8 +78,8 @@ namespace CodeJam.IO
 		[TestCase(@"a:\a\..\a..b\", PathKind.Invalid)]
 		[TestCase(@"\", PathKind.Invalid)]
 		[TestCase(@"/", PathKind.Invalid)]
-		[TestCase(@"~", PathKind.ValidSimpleName)]
-		[TestCase(@"a", PathKind.ValidSimpleName)]
+		[TestCase(@"~", PathKind.ValidFileName)]
+		[TestCase(@"a", PathKind.ValidFileName)]
 		[TestCase(@"a:", PathKind.Invalid)]
 		[TestCase(@"a\", PathKind.ValidRelativeContainerPath)]
 		[TestCase(@"a/", PathKind.ValidRelativeContainerPath)]
@@ -112,8 +123,8 @@ namespace CodeJam.IO
 		[TestCase(@"a:\/a", PathKind.Invalid)]
 		[TestCase(@"a\\a", PathKind.ValidRelativePath)]
 		[TestCase(@"a\/a", PathKind.ValidRelativePath)]
-		[TestCase(@"com0", PathKind.ValidSimpleName)]
-		[TestCase(@"aux", PathKind.ValidSimpleName)]
+		[TestCase(@"com0", PathKind.ValidFileName)]
+		[TestCase(@"aux", PathKind.ValidFileName)]
 		public void TestIsWellFormedPath(string path, PathKind pathState)
 		{
 			switch (pathState)
@@ -123,49 +134,49 @@ namespace CodeJam.IO
 					Assert.Throws<ArgumentException>(() => PathHelpers.IsWellFormedAbsolutePath(path));
 					Assert.Throws<ArgumentException>(() => PathHelpers.IsWellFormedRelativePath(path));
 					Assert.Throws<ArgumentException>(() => PathHelpers.IsWellFormedContainerPath(path));
-					Assert.Throws<ArgumentException>(() => PathHelpers.IsWellFormedSimpleName(path));
+					Assert.Throws<ArgumentException>(() => PathHelpers.IsWellFormedFileName(path));
 					break;
 				case PathKind.Invalid:
 					Assert.AreEqual(PathHelpers.IsWellFormedPath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedAbsolutePath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedRelativePath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedContainerPath(path), false);
-					Assert.AreEqual(PathHelpers.IsWellFormedSimpleName(path), false);
+					Assert.AreEqual(PathHelpers.IsWellFormedFileName(path), false);
 					break;
 				case PathKind.ValidAbsolutePath:
 					Assert.AreEqual(PathHelpers.IsWellFormedPath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedAbsolutePath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedRelativePath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedContainerPath(path), false);
-					Assert.AreEqual(PathHelpers.IsWellFormedSimpleName(path), false);
+					Assert.AreEqual(PathHelpers.IsWellFormedFileName(path), false);
 					break;
 				case PathKind.ValidAbsoluteContainerPath:
 					Assert.AreEqual(PathHelpers.IsWellFormedPath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedAbsolutePath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedRelativePath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedContainerPath(path), true);
-					Assert.AreEqual(PathHelpers.IsWellFormedSimpleName(path), false);
+					Assert.AreEqual(PathHelpers.IsWellFormedFileName(path), false);
 					break;
 				case PathKind.ValidRelativePath:
 					Assert.AreEqual(PathHelpers.IsWellFormedPath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedAbsolutePath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedRelativePath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedContainerPath(path), false);
-					Assert.AreEqual(PathHelpers.IsWellFormedSimpleName(path), false);
+					Assert.AreEqual(PathHelpers.IsWellFormedFileName(path), false);
 					break;
 				case PathKind.ValidRelativeContainerPath:
 					Assert.AreEqual(PathHelpers.IsWellFormedPath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedAbsolutePath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedRelativePath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedContainerPath(path), true);
-					Assert.AreEqual(PathHelpers.IsWellFormedSimpleName(path), false);
+					Assert.AreEqual(PathHelpers.IsWellFormedFileName(path), false);
 					break;
-				case PathKind.ValidSimpleName:
+				case PathKind.ValidFileName:
 					Assert.AreEqual(PathHelpers.IsWellFormedPath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedAbsolutePath(path), false);
 					Assert.AreEqual(PathHelpers.IsWellFormedRelativePath(path), true);
 					Assert.AreEqual(PathHelpers.IsWellFormedContainerPath(path), false);
-					Assert.AreEqual(PathHelpers.IsWellFormedSimpleName(path), true);
+					Assert.AreEqual(PathHelpers.IsWellFormedFileName(path), true);
 					break;
 				default:
 					throw new ArgumentOutOfRangeException(nameof(pathState), pathState, null);
@@ -236,18 +247,18 @@ namespace CodeJam.IO
 		[TestCase(@"a:/", false)]
 		[TestCase(@"a:\a", false)]
 		[TestCase(@"a:/a", false)]
-		public void TestIsSimpleName(string path, bool? state)
+		public void TestIsFileName(string path, bool? state)
 		{
 			switch (state)
 			{
 				case null:
-					Assert.Throws<ArgumentException>(() => PathHelpers.IsSimpleName(path));
+					Assert.Throws<ArgumentException>(() => PathHelpers.IsFileName(path));
 					break;
 				case true:
-					Assert.AreEqual(PathHelpers.IsSimpleName(path), true);
+					Assert.AreEqual(PathHelpers.IsFileName(path), true);
 					break;
 				case false:
-					Assert.AreEqual(PathHelpers.IsSimpleName(path), false);
+					Assert.AreEqual(PathHelpers.IsFileName(path), false);
 					break;
 				default:
 					throw new ArgumentOutOfRangeException(nameof(state), state, null);

--- a/CodeJam.Main/Assertions/ArgumentAssertionExtensions.cs
+++ b/CodeJam.Main/Assertions/ArgumentAssertionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -56,44 +55,44 @@ namespace CodeJam
 		}
 
 		/// <summary>
-		/// Ensures that supplied enumerable is not empty.
+		/// Ensures that supplied enumerable is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">The argument.</param>
 		/// <returns><paramref name="arg"/></returns>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static ArgumentAssertion<IEnumerable<T>> NotEmpty<T>(this ArgumentAssertion<IEnumerable<T>> arg)
+		public static ArgumentAssertion<IEnumerable<T>> NotNullNorEmpty<T>(this ArgumentAssertion<IEnumerable<T>> arg)
 		{
-			Code.NotEmpty(arg.Argument, arg.ArgumentName);
+			Code.NotNullNorEmpty(arg.Argument, arg.ArgumentName);
 			return arg;
 		}
 
 		/// <summary>
-		/// Ensures that supplied collection is not empty.
+		/// Ensures that supplied collection is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">The argument.</param>
 		/// <returns><paramref name="arg"/></returns>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static ArgumentAssertion<ICollection<T>> NotEmpty<T>(this ArgumentAssertion<ICollection<T>> arg)
+		public static ArgumentAssertion<ICollection<T>> NotNullNorEmpty<T>(this ArgumentAssertion<ICollection<T>> arg)
 		{
-			Code.NotEmpty(arg.Argument, arg.ArgumentName);
+			Code.NotNullNorEmpty(arg.Argument, arg.ArgumentName);
 			return arg;
 		}
 
 		/// <summary>
-		/// Ensures that supplied array is not empty.
+		/// Ensures that supplied array is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">The argument.</param>
 		/// <returns><paramref name="arg"/></returns>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static ArgumentAssertion<T[]> NotEmpty<T>(this ArgumentAssertion<T[]> arg)
+		public static ArgumentAssertion<T[]> NotNullNorEmpty<T>(this ArgumentAssertion<T[]> arg)
 		{
-			Code.NotEmpty(arg.Argument, arg.ArgumentName);
+			Code.NotNullNorEmpty(arg.Argument, arg.ArgumentName);
 			return arg;
 		}
 
@@ -127,9 +126,10 @@ namespace CodeJam
 		/// <returns><paramref name="arg"/></returns>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
+		[ContractAnnotation("condition: false => halt")]
 		public static ArgumentAssertion<T> Assert<T>(
 			this ArgumentAssertion<T> arg,
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull] string message)
 		{
 			Code.AssertArgument(condition, arg.ArgumentName, message);
@@ -145,9 +145,10 @@ namespace CodeJam
 		/// <returns><paramref name="arg"/></returns>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod, StringFormatMethod("messageFormat")]
+		[ContractAnnotation("condition: false => halt")]
 		public static ArgumentAssertion<T> Assert<T>(
 			this ArgumentAssertion<T> arg,
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
 		{

--- a/CodeJam.Main/Assertions/Code.NonDebug.cs
+++ b/CodeJam.Main/Assertions/Code.NonDebug.cs
@@ -12,7 +12,9 @@ namespace CodeJam
 	// Part that excluded from debug assertions generation.
 	partial class Code
 	{
-		#region Argument validation
+		#region Argument validation (DO NOT copy into DebugCode)
+		// NB: Conditional methods cannot have a return type.
+
 		/// <summary>
 		/// Creates <see cref="ArgumentAssertion{T}"/> for fluent assertions.
 		/// </summary>
@@ -21,6 +23,7 @@ namespace CodeJam
 		/// <param name="argName">Argument name.</param>
 		/// <returns><see cref="ArgumentAssertion{T}"/> instance.</returns>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
+		[MustUseReturnValue]
 		[AssertionMethod]
 		public static ArgumentAssertion<T> Arg<T>(T arg, [InvokerParameterName] string argName) =>
 			new ArgumentAssertion<T>(arg, argName);
@@ -88,8 +91,9 @@ namespace CodeJam
 		/// <param name="thisReference">The this reference.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
+		[ContractAnnotation("resource: null => halt")]
 		public static void DisposedIfNull<TResource, TDisposable>(
-			[CanBeNull] TResource resource,
+			[CanBeNull, NoEnumeration] TResource resource,
 			[NotNull] TDisposable thisReference)
 			where TResource : class
 			where TDisposable : IDisposable
@@ -106,8 +110,9 @@ namespace CodeJam
 		/// <param name="message">The message.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
+		[ContractAnnotation("resource: null => halt")]
 		public static void DisposedIfNull<TResource, TDisposable>(
-			[CanBeNull] TResource resource,
+			[CanBeNull, NoEnumeration] TResource resource,
 			[NotNull] TDisposable thisReference,
 			[NotNull] string message)
 			where TResource : class
@@ -126,8 +131,9 @@ namespace CodeJam
 		/// <param name="args">The arguments.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod, StringFormatMethod("messageFormat")]
+		[ContractAnnotation("resource: null => halt")]
 		public static void DisposedIfNull<TResource, TDisposable>(
-			[CanBeNull] TResource resource,
+			[CanBeNull, NoEnumeration] TResource resource,
 			[NotNull] TDisposable thisReference,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)

--- a/CodeJam.Main/Assertions/Code.cs
+++ b/CodeJam.Main/Assertions/Code.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 using CodeJam.Arithmetic;
@@ -24,41 +26,31 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("arg: null => halt")]
 		public static void NotNull<T>(
-			[CanBeNull, NoEnumeration, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T arg,
+			[CanBeNull, NoEnumeration] T arg,
 			[NotNull, InvokerParameterName] string argName) where T : class
 		{
 			if (arg == null)
 				throw CodeExceptions.ArgumentNull(argName);
 		}
 
-		/// <summary>Ensures that all items in <paramref name="arg"/> != <c>null</c></summary>
+		/// <summary>Ensures that <paramref name="arg"/> != <c>null</c></summary>
 		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
 		/// <param name="arg">The argument.</param>
 		/// <param name="argName">Name of the argument.</param>
+		/// <remarks>
+		/// This version enables not-null assertions for generic methods without
+		/// <code>where T : class</code> constraint.
+		/// </remarks>
+		[EditorBrowsable(EditorBrowsableState.Advanced)]
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void ItemNotNull<T>(
-			[NotNull] IEnumerable<T> arg,
-			[NotNull, InvokerParameterName] string argName) where T : class
-		{
-			foreach (var item in arg)
-				if (item == null)
-					throw CodeExceptions.ArgumentItemNull(argName);
-		}
-
-		/// <summary>Ensures that <paramref name="arg"/> and its all items != <c>null</c></summary>
-		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
-		/// <param name="arg">The argument.</param>
-		/// <param name="argName">Name of the argument.</param>
-		[DebuggerHidden, MethodImpl(AggressiveInlining)]
-		[AssertionMethod]
-		public static void NotNullAndItemNotNull<T>(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] IEnumerable<T> arg,
-			[NotNull, InvokerParameterName] string argName) where T : class
+		[ContractAnnotation("arg: null => halt")]
+		public static void GenericNotNull<T>(
+			[CanBeNull, NoEnumeration] T arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
 			if (arg == null)
 				throw CodeExceptions.ArgumentNull(argName);
-			ItemNotNull(arg, argName);
 		}
 
 		/// <summary>Ensures that <paramref name="arg"/> != <c>null</c></summary>
@@ -69,7 +61,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("arg: null => halt")]
 		public static void NotNull<T>(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T? arg,
+			[CanBeNull] T? arg,
 			[NotNull, InvokerParameterName] string argName) where T : struct
 		{
 			if (arg == null)
@@ -77,44 +69,58 @@ namespace CodeJam
 		}
 
 		/// <summary>
-		/// Ensures that supplied enumerable is not empty.
+		/// Ensures that supplied enumerable is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">Enumerable.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void NotEmpty<T>([NotNull] IEnumerable<T> arg, [NotNull, InvokerParameterName] string argName)
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullNorEmpty<T>(
+			[CanBeNull, InstantHandle] IEnumerable<T> arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
-			using var en = arg.GetEnumerator();
-			if (!en.MoveNext())
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
+			if (!arg.Any())
 				throw CodeExceptions.ArgumentEmpty(argName);
 		}
 
 		/// <summary>
-		/// Ensures that supplied collection is not empty.
+		/// Ensures that supplied collection is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">Collection.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void NotEmpty<T>([NotNull] ICollection<T> arg, [NotNull, InvokerParameterName] string argName)
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullNorEmpty<T>(
+			[CanBeNull] ICollection<T> arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
 			if (arg.Count == 0)
 				throw CodeExceptions.ArgumentEmpty(argName);
 		}
 
 		/// <summary>
-		/// Ensures that supplied array is not empty.
+		/// Ensures that supplied array is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">Array.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void NotEmpty<T>([NotNull] T[] arg, [NotNull, InvokerParameterName] string argName)
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullNorEmpty<T>(
+			[CanBeNull] T[] arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
 			if (arg.Length == 0)
 				throw CodeExceptions.ArgumentEmpty(argName);
 		}
@@ -124,9 +130,9 @@ namespace CodeJam
 		/// <param name="argName">Name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		[ContractAnnotation("arg:null => stop")]
+		[ContractAnnotation("arg: null => halt")]
 		public static void NotNullNorEmpty(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string arg,
+			[CanBeNull] string arg,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			if (string.IsNullOrEmpty(arg))
@@ -138,13 +144,44 @@ namespace CodeJam
 		/// <param name="argName">Name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		[ContractAnnotation("arg:null => stop")]
+		[ContractAnnotation("arg: null => halt")]
 		public static void NotNullNorWhiteSpace(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string arg,
+			[CanBeNull] string arg,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			if (arg.IsNullOrWhiteSpace())
 				throw CodeExceptions.ArgumentNullOrWhiteSpace(argName);
+		}
+
+		/// <summary>Ensures that <paramref name="arg"/> and its all items != <c>null</c></summary>
+		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
+		/// <param name="arg">The argument.</param>
+		/// <param name="argName">Name of the argument.</param>
+		[DebuggerHidden, MethodImpl(AggressiveInlining)]
+		[AssertionMethod]
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullAndItemNotNull<T>(
+			[CanBeNull, InstantHandle] IEnumerable<T> arg,
+			[NotNull, InvokerParameterName] string argName) where T : class
+		{
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
+			ItemNotNull(arg, argName);
+		}
+
+		/// <summary>Ensures that all items in <paramref name="arg"/> != <c>null</c></summary>
+		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
+		/// <param name="arg">The argument.</param>
+		/// <param name="argName">Name of the argument.</param>
+		[DebuggerHidden, MethodImpl(AggressiveInlining)]
+		[AssertionMethod]
+		public static void ItemNotNull<T>(
+			[NotNull, InstantHandle] IEnumerable<T> arg,
+			[NotNull, InvokerParameterName] string argName) where T : class
+		{
+			foreach (var item in arg)
+				if (item == null)
+					throw CodeExceptions.ArgumentItemNull(argName);
 		}
 
 		/// <summary>Assertion for the argument value</summary>
@@ -155,7 +192,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertArgument(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull, InvokerParameterName] string argName,
 			[NotNull] string message)
 		{
@@ -172,7 +209,7 @@ namespace CodeJam
 		[AssertionMethod, StringFormatMethod("messageFormat")]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertArgument(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull, InvokerParameterName] string argName,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
@@ -245,8 +282,8 @@ namespace CodeJam
 		/// <param name="argName">The name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void ValidCount(int count, [NotNull, InvokerParameterName] string argName)
-			=> InRange(count, argName, 0, int.MaxValue);
+		public static void ValidCount(int count, [NotNull, InvokerParameterName] string argName) =>
+			InRange(count, argName, 0, int.MaxValue);
 
 		/// <summary>Asserts if the passed value is not a valid count.</summary>
 		/// <param name="count">The count value.</param>
@@ -254,10 +291,11 @@ namespace CodeJam
 		/// <param name="length">The length.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void ValidCount(int count,
+		public static void ValidCount(
+			int count,
 			[NotNull, InvokerParameterName] string argName,
-			int length)
-				=> InRange(count, argName, 0, length);
+			int length) =>
+			InRange(count, argName, 0, length);
 		#endregion
 
 		#region Argument validation - valid index
@@ -339,7 +377,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertState(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull] string message)
 		{
 			if (!condition)
@@ -354,7 +392,7 @@ namespace CodeJam
 		[AssertionMethod, StringFormatMethod("messageFormat")]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertState(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
 		{
@@ -371,7 +409,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("condition: true => halt")]
 		public static void BugIf(
-			[AssertionCondition(AssertionConditionType.IS_FALSE)] bool condition,
+			bool condition,
 			[NotNull] string message)
 		{
 			if (condition)
@@ -386,7 +424,7 @@ namespace CodeJam
 		[AssertionMethod, StringFormatMethod("messageFormat")]
 		[ContractAnnotation("condition: true => halt")]
 		public static void BugIf(
-			[AssertionCondition(AssertionConditionType.IS_FALSE)] bool condition,
+			bool condition,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
 		{

--- a/CodeJam.Main/Assertions/CodeExceptions.cs
+++ b/CodeJam.Main/Assertions/CodeExceptions.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelpers;
-using static CodeJam.Targeting.MethodImplOptionsEx;
 
 namespace CodeJam
 {
@@ -17,8 +15,7 @@ namespace CodeJam
 		/// <summary>Creates <see cref="ArgumentNullException"/>.</summary>
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentNullException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentNullException ArgumentNull([NotNull, InvokerParameterName] string argumentName)
 		{
 			BreakIfAttached();
@@ -28,13 +25,13 @@ namespace CodeJam
 		/// <summary>Creates <see cref="ArgumentNullException"/>.</summary>
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentItemNull([NotNull, InvokerParameterName] string argumentName)
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				argumentName, $"All items in '{argumentName}' should not be null.")
+				$"All items in '{argumentName}' should not be null.",
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -43,22 +40,20 @@ namespace CodeJam
 		/// </summary>
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/></returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentEmpty([NotNull, InvokerParameterName] string argumentName)
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				argumentName,
-				$"Collection {argumentName} must not be empty.")
+				$"Collection '{argumentName}' must not be empty.",
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
 		/// <summary>Creates <see cref="ArgumentException"/> for empty string.</summary>
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentNullOrEmpty([NotNull, InvokerParameterName] string argumentName)
 		{
 			BreakIfAttached();
@@ -71,8 +66,7 @@ namespace CodeJam
 		/// <summary>Creates <see cref="ArgumentException"/> for empty (or whitespace) string.</summary>
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentNullOrWhiteSpace([NotNull, InvokerParameterName] string argumentName)
 		{
 			BreakIfAttached();
@@ -88,8 +82,7 @@ namespace CodeJam
 		/// <param name="fromValue">From value (inclusive).</param>
 		/// <param name="toValue">To value (inclusive).</param>
 		/// <returns>Initialized instance of <see cref="ArgumentOutOfRangeException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentOutOfRangeException ArgumentOutOfRange(
 			[NotNull, InvokerParameterName] string argumentName,
 			int value, int fromValue, int toValue)
@@ -98,7 +91,7 @@ namespace CodeJam
 			return new ArgumentOutOfRangeException(
 				argumentName,
 				value,
-				$"The value of '{argumentName}' ({value.ToInv()}) should be between {fromValue.ToInv()} and {toValue.ToInv()}.")
+				Invariant($"The value of '{argumentName}' ({value}) should be between {fromValue} and {toValue}."))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -108,8 +101,7 @@ namespace CodeJam
 		/// <param name="fromValue">From value (inclusive).</param>
 		/// <param name="toValue">To value (inclusive).</param>
 		/// <returns>Initialized instance of <see cref="ArgumentOutOfRangeException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentOutOfRangeException ArgumentOutOfRange(
 			[NotNull, InvokerParameterName] string argumentName,
 			double value, double fromValue, double toValue)
@@ -118,7 +110,7 @@ namespace CodeJam
 			return new ArgumentOutOfRangeException(
 				argumentName,
 				value,
-				$"The value of '{argumentName}' ({value.ToInv()}) should be between {fromValue.ToInv()} and {toValue.ToInv()}.")
+				Invariant($"The value of '{argumentName}' ({value}) should be between {fromValue} and {toValue}."))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -129,8 +121,7 @@ namespace CodeJam
 		/// <param name="fromValue">From value (inclusive).</param>
 		/// <param name="toValue">To value (inclusive).</param>
 		/// <returns>Initialized instance of <see cref="ArgumentOutOfRangeException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentOutOfRangeException ArgumentOutOfRange<T>(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] T value,
@@ -141,7 +132,7 @@ namespace CodeJam
 			return new ArgumentOutOfRangeException(
 				argumentName,
 				value,
-				$"The value of '{argumentName}' ('{value.ToInv()}') should be between '{fromValue.ToInv()}' and '{toValue.ToInv()}'.")
+				Invariant($"The value of '{argumentName}' ('{value}') should be between '{fromValue}' and '{toValue}'."))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -151,15 +142,15 @@ namespace CodeJam
 		/// <param name="startIndex">The start index.</param>
 		/// <param name="length">The length.</param>
 		/// <returns>Initialized instance of <see cref="IndexOutOfRangeException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static IndexOutOfRangeException IndexOutOfRange(
 			[NotNull, InvokerParameterName] string argumentName,
 			int value, int startIndex, int length)
 		{
 			BreakIfAttached();
 			return new IndexOutOfRangeException(
-				$"The value of '{argumentName}' ({value.ToInv()}) should be greater than or equal to {startIndex.ToInv()} and less than {length.ToInv()}.")
+				Invariant(
+					$"The value of '{argumentName}' ({value}) should be greater than or equal to {startIndex} and less than {length}."))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 		#endregion
@@ -170,9 +161,8 @@ namespace CodeJam
 		/// <param name="messageFormat">The message format.</param>
 		/// <param name="args">The arguments.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static ArgumentException Argument(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string messageFormat,
@@ -180,7 +170,8 @@ namespace CodeJam
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				FormatExceptionMessage(messageFormat, args), argumentName)
+				InvariantFormat(messageFormat, args),
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -188,16 +179,14 @@ namespace CodeJam
 		/// <param name="messageFormat">The message format.</param>
 		/// <param name="args">The arguments.</param>
 		/// <returns>Initialized instance of <see cref="InvalidOperationException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static InvalidOperationException InvalidOperation(
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
 		{
 			BreakIfAttached();
-			return new InvalidOperationException(
-				FormatExceptionMessage(messageFormat, args))
+			return new InvalidOperationException(InvariantFormat(messageFormat, args))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 		#endregion
@@ -211,8 +200,7 @@ namespace CodeJam
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="value">The value.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentOutOfRangeException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentOutOfRangeException UnexpectedArgumentValue<T>(
 			[NotNull, InvokerParameterName] string argumentName,
 			[CanBeNull] T value)
@@ -220,7 +208,9 @@ namespace CodeJam
 			BreakIfAttached();
 			var valueType = value?.GetType() ?? typeof(T);
 			return new ArgumentOutOfRangeException(
-				argumentName, value, $"Unexpected value '{value?.ToInv()}' of type '{valueType.FullName}'.")
+				argumentName,
+				value,
+				Invariant($"Unexpected value '{value}' of type '{valueType.FullName}'."))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -234,9 +224,8 @@ namespace CodeJam
 		/// <param name="messageFormat">The message format.</param>
 		/// <param name="args">The arguments.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentOutOfRangeException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static ArgumentOutOfRangeException UnexpectedArgumentValue<T>(
 			[NotNull, InvokerParameterName] string argumentName,
 			[CanBeNull] T value,
@@ -244,8 +233,9 @@ namespace CodeJam
 		{
 			BreakIfAttached();
 			return new ArgumentOutOfRangeException(
-				argumentName, value,
-				FormatExceptionMessage(messageFormat, args))
+				argumentName,
+				value,
+				InvariantFormat(messageFormat, args))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -256,16 +246,14 @@ namespace CodeJam
 		/// <typeparam name="T">The type of the value. Auto-inferred.</typeparam>
 		/// <param name="value">The value.</param>
 		/// <returns>Initialized instance of <see cref="InvalidOperationException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static InvalidOperationException UnexpectedValue<T>([CanBeNull] T value)
 		{
 			BreakIfAttached();
 			var valueType = value?.GetType() ?? typeof(T);
-			return
-				new InvalidOperationException(
-					$"Unexpected value '{value?.ToInv()}' of type '{valueType.FullName}'.")
-					.LogToCodeTraceSourceBeforeThrow();
+			return new InvalidOperationException(
+				Invariant($"Unexpected value '{value}' of type '{valueType.FullName}'."))
+				.LogToCodeTraceSourceBeforeThrow();
 		}
 
 		/// <summary>
@@ -275,28 +263,24 @@ namespace CodeJam
 		/// <param name="messageFormat">The message format.</param>
 		/// <param name="args">The arguments.</param>
 		/// <returns>Initialized instance of <see cref="InvalidOperationException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static InvalidOperationException UnexpectedValue(
 			[NotNull] string messageFormat, [CanBeNull] params object[] args)
 		{
 			BreakIfAttached();
-			return new InvalidOperationException(
-				FormatExceptionMessage(messageFormat, args))
+			return new InvalidOperationException(InvariantFormat(messageFormat, args))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
 		/// <summary>Throw this if the object is disposed.</summary>
 		/// <param name="typeofDisposedObject">The typeof disposed object.</param>
 		/// <returns>Initialized instance of <see cref="ObjectDisposedException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ObjectDisposedException ObjectDisposed([CanBeNull] Type typeofDisposedObject)
 		{
 			BreakIfAttached();
-			return new ObjectDisposedException(
-				typeofDisposedObject?.FullName)
+			return new ObjectDisposedException(typeofDisposedObject?.FullName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -305,33 +289,30 @@ namespace CodeJam
 		/// <param name="messageFormat">The message format.</param>
 		/// <param name="args">The arguments.</param>
 		/// <returns>Initialized instance of <see cref="ObjectDisposedException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static ObjectDisposedException ObjectDisposed(
 			[CanBeNull] Type typeofDisposedObject,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
 		{
 			BreakIfAttached();
-			return
-				new ObjectDisposedException(
-					typeofDisposedObject?.FullName, FormatExceptionMessage(messageFormat, args))
-					.LogToCodeTraceSourceBeforeThrow();
+			return new ObjectDisposedException(
+				typeofDisposedObject?.FullName,
+				InvariantFormat(messageFormat, args))
+				.LogToCodeTraceSourceBeforeThrow();
 		}
 
 		/// <summary>Used to be thrown in places expected to be unreachable.</summary>
 		/// <param name="messageFormat">The message format.</param>
 		/// <param name="args">The arguments.</param>
 		/// <returns>Initialized instance of <see cref="NotSupportedException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static NotSupportedException Unreachable([NotNull] string messageFormat, [CanBeNull] params object[] args)
 		{
 			BreakIfAttached();
-			return new NotSupportedException(
-				FormatExceptionMessage(messageFormat, args))
+			return new NotSupportedException(InvariantFormat(messageFormat, args))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 		#endregion

--- a/CodeJam.Main/Assertions/CodeExceptionsHelpers.cs
+++ b/CodeJam.Main/Assertions/CodeExceptionsHelpers.cs
@@ -9,6 +9,7 @@ using static CodeJam.Targeting.MethodImplOptionsEx;
 
 using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 
+// ReSharper disable once CheckNamespace
 namespace CodeJam.Internal
 {
 	/// <summary>Helper class for custom code exception factory classes</summary>
@@ -40,23 +41,24 @@ namespace CodeJam.Internal
 		/// <param name="args">The arguments.</param>
 		/// <returns>Formatted string.</returns>
 		[SuppressMessage("ReSharper", "ArrangeRedundantParentheses")]
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		public static string FormatExceptionMessage([NotNull] string messageFormat, [CanBeNull] params object[] args) =>
+		public static string InvariantFormat([NotNull] string messageFormat, [CanBeNull] params object[] args) =>
 			(args == null || args.Length == 0)
 				? messageFormat
 				: string.Format(CultureInfo.InvariantCulture, messageFormat, args);
 
 		/// <summary>
-		/// Returns culture-invariant representation of passed value.
+		/// Formats message.
 		/// </summary>
-		public static string ToInv<T>([NotNull] this T value)
-		{
-			if (value is IFormattable f)
-				return f.ToString(null, CultureInfo.InvariantCulture);
-			return value.ToString();
-		}
+		/// <param name="messageFormat">The message format.</param>
+		/// <returns>Formatted string.</returns>
+		[SuppressMessage("ReSharper", "ArrangeRedundantParentheses")]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
+		[StringFormatMethod("messageFormat")]
+		internal static string Invariant([NotNull] FormattableString messageFormat) =>
+			messageFormat.ToString(CultureInfo.InvariantCulture);
+
 		#endregion
 
 		#region Logging
@@ -65,8 +67,7 @@ namespace CodeJam.Internal
 		[NotNull]
 		public static TraceSource CodeTraceSource => _codeTraceSource.Value;
 
-		[NotNull]
-		[ItemNotNull]
+		[NotNull, ItemNotNull]
 		private static readonly Lazy<TraceSource> _codeTraceSource = new Lazy<TraceSource>(
 			() => CreateTraceSource(typeof(Code).Namespace + "." + nameof(CodeTraceSource)));
 
@@ -84,8 +85,7 @@ namespace CodeJam.Internal
 		/// <typeparam name="TException">The type of the exception.</typeparam>
 		/// <param name="exception">The exception.</param>
 		/// <returns>The original exception.</returns>
-		[NotNull]
-		[MustUseReturnValue]
+		[NotNull, MustUseReturnValue]
 		public static TException LogToCodeTraceSourceBeforeThrow<TException>([NotNull] this TException exception)
 			where TException : Exception
 		{

--- a/CodeJam.Main/Assertions/DebugCode.generated.cs
+++ b/CodeJam.Main/Assertions/DebugCode.generated.cs
@@ -10,7 +10,9 @@
 using static CodeJam.DebugCode;
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 using CodeJam.Arithmetic;
@@ -35,41 +37,31 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("arg: null => halt")]
 		public static void NotNull<T>(
-			[CanBeNull, NoEnumeration, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T arg,
+			[CanBeNull, NoEnumeration] T arg,
 			[NotNull, InvokerParameterName] string argName) where T : class
 		{
 			if (arg == null)
 				throw CodeExceptions.ArgumentNull(argName);
 		}
 
-		/// <summary>Ensures that all items in <paramref name="arg"/> != <c>null</c></summary>
+		/// <summary>Ensures that <paramref name="arg"/> != <c>null</c></summary>
 		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
 		/// <param name="arg">The argument.</param>
 		/// <param name="argName">Name of the argument.</param>
+		/// <remarks>
+		/// This version enables not-null assertions for generic methods without
+		/// <code>where T : class</code> constraint.
+		/// </remarks>
+		[EditorBrowsable(EditorBrowsableState.Advanced)]
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void ItemNotNull<T>(
-			[NotNull] IEnumerable<T> arg,
-			[NotNull, InvokerParameterName] string argName) where T : class
-		{
-			foreach (var item in arg)
-				if (item == null)
-					throw CodeExceptions.ArgumentItemNull(argName);
-		}
-
-		/// <summary>Ensures that <paramref name="arg"/> and its all items != <c>null</c></summary>
-		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
-		/// <param name="arg">The argument.</param>
-		/// <param name="argName">Name of the argument.</param>
-		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
-		[AssertionMethod]
-		public static void NotNullAndItemNotNull<T>(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] IEnumerable<T> arg,
-			[NotNull, InvokerParameterName] string argName) where T : class
+		[ContractAnnotation("arg: null => halt")]
+		public static void GenericNotNull<T>(
+			[CanBeNull, NoEnumeration] T arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
 			if (arg == null)
 				throw CodeExceptions.ArgumentNull(argName);
-			ItemNotNull(arg, argName);
 		}
 
 		/// <summary>Ensures that <paramref name="arg"/> != <c>null</c></summary>
@@ -80,7 +72,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("arg: null => halt")]
 		public static void NotNull<T>(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] T? arg,
+			[CanBeNull] T? arg,
 			[NotNull, InvokerParameterName] string argName) where T : struct
 		{
 			if (arg == null)
@@ -88,44 +80,58 @@ namespace CodeJam
 		}
 
 		/// <summary>
-		/// Ensures that supplied enumerable is not empty.
+		/// Ensures that supplied enumerable is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">Enumerable.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void NotEmpty<T>([NotNull] IEnumerable<T> arg, [NotNull, InvokerParameterName] string argName)
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullNorEmpty<T>(
+			[CanBeNull, InstantHandle] IEnumerable<T> arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
-			using var en = arg.GetEnumerator();
-			if (!en.MoveNext())
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
+			if (!arg.Any())
 				throw CodeExceptions.ArgumentEmpty(argName);
 		}
 
 		/// <summary>
-		/// Ensures that supplied collection is not empty.
+		/// Ensures that supplied collection is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">Collection.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void NotEmpty<T>([NotNull] ICollection<T> arg, [NotNull, InvokerParameterName] string argName)
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullNorEmpty<T>(
+			[CanBeNull] ICollection<T> arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
 			if (arg.Count == 0)
 				throw CodeExceptions.ArgumentEmpty(argName);
 		}
 
 		/// <summary>
-		/// Ensures that supplied array is not empty.
+		/// Ensures that supplied array is not null nor empty.
 		/// </summary>
 		/// <typeparam name="T">Type of item.</typeparam>
 		/// <param name="arg">Array.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void NotEmpty<T>([NotNull] T[] arg, [NotNull, InvokerParameterName] string argName)
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullNorEmpty<T>(
+			[CanBeNull] T[] arg,
+			[NotNull, InvokerParameterName] string argName)
 		{
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
 			if (arg.Length == 0)
 				throw CodeExceptions.ArgumentEmpty(argName);
 		}
@@ -135,9 +141,9 @@ namespace CodeJam
 		/// <param name="argName">Name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		[ContractAnnotation("arg:null => stop")]
+		[ContractAnnotation("arg: null => halt")]
 		public static void NotNullNorEmpty(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string arg,
+			[CanBeNull] string arg,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			if (string.IsNullOrEmpty(arg))
@@ -149,13 +155,44 @@ namespace CodeJam
 		/// <param name="argName">Name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		[ContractAnnotation("arg:null => stop")]
+		[ContractAnnotation("arg: null => halt")]
 		public static void NotNullNorWhiteSpace(
-			[CanBeNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL)] string arg,
+			[CanBeNull] string arg,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			if (arg.IsNullOrWhiteSpace())
 				throw CodeExceptions.ArgumentNullOrWhiteSpace(argName);
+		}
+
+		/// <summary>Ensures that <paramref name="arg"/> and its all items != <c>null</c></summary>
+		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
+		/// <param name="arg">The argument.</param>
+		/// <param name="argName">Name of the argument.</param>
+		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
+		[AssertionMethod]
+		[ContractAnnotation("arg: null => halt")]
+		public static void NotNullAndItemNotNull<T>(
+			[CanBeNull, InstantHandle] IEnumerable<T> arg,
+			[NotNull, InvokerParameterName] string argName) where T : class
+		{
+			if (arg == null)
+				throw CodeExceptions.ArgumentNull(argName);
+			ItemNotNull(arg, argName);
+		}
+
+		/// <summary>Ensures that all items in <paramref name="arg"/> != <c>null</c></summary>
+		/// <typeparam name="T">Type of the value. Auto-inferred in most cases</typeparam>
+		/// <param name="arg">The argument.</param>
+		/// <param name="argName">Name of the argument.</param>
+		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
+		[AssertionMethod]
+		public static void ItemNotNull<T>(
+			[NotNull, InstantHandle] IEnumerable<T> arg,
+			[NotNull, InvokerParameterName] string argName) where T : class
+		{
+			foreach (var item in arg)
+				if (item == null)
+					throw CodeExceptions.ArgumentItemNull(argName);
 		}
 
 		/// <summary>Assertion for the argument value</summary>
@@ -166,7 +203,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertArgument(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull, InvokerParameterName] string argName,
 			[NotNull] string message)
 		{
@@ -183,7 +220,7 @@ namespace CodeJam
 		[AssertionMethod, StringFormatMethod("messageFormat")]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertArgument(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull, InvokerParameterName] string argName,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
@@ -256,8 +293,8 @@ namespace CodeJam
 		/// <param name="argName">The name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void ValidCount(int count, [NotNull, InvokerParameterName] string argName)
-			=> InRange(count, argName, 0, int.MaxValue);
+		public static void ValidCount(int count, [NotNull, InvokerParameterName] string argName) =>
+			InRange(count, argName, 0, int.MaxValue);
 
 		/// <summary>Asserts if the passed value is not a valid count.</summary>
 		/// <param name="count">The count value.</param>
@@ -265,10 +302,11 @@ namespace CodeJam
 		/// <param name="length">The length.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void ValidCount(int count,
+		public static void ValidCount(
+			int count,
 			[NotNull, InvokerParameterName] string argName,
-			int length)
-				=> InRange(count, argName, 0, length);
+			int length) =>
+			InRange(count, argName, 0, length);
 		#endregion
 
 		#region Argument validation - valid index
@@ -350,7 +388,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertState(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull] string message)
 		{
 			if (!condition)
@@ -365,7 +403,7 @@ namespace CodeJam
 		[AssertionMethod, StringFormatMethod("messageFormat")]
 		[ContractAnnotation("condition: false => halt")]
 		public static void AssertState(
-			[AssertionCondition(AssertionConditionType.IS_TRUE)] bool condition,
+			bool condition,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
 		{
@@ -382,7 +420,7 @@ namespace CodeJam
 		[AssertionMethod]
 		[ContractAnnotation("condition: true => halt")]
 		public static void BugIf(
-			[AssertionCondition(AssertionConditionType.IS_FALSE)] bool condition,
+			bool condition,
 			[NotNull] string message)
 		{
 			if (condition)
@@ -397,7 +435,7 @@ namespace CodeJam
 		[AssertionMethod, StringFormatMethod("messageFormat")]
 		[ContractAnnotation("condition: true => halt")]
 		public static void BugIf(
-			[AssertionCondition(AssertionConditionType.IS_FALSE)] bool condition,
+			bool condition,
 			[NotNull] string messageFormat,
 			[CanBeNull] params object[] args)
 		{

--- a/CodeJam.Main/Assertions/DebugEnumCode.generated.cs
+++ b/CodeJam.Main/Assertions/DebugEnumCode.generated.cs
@@ -36,7 +36,7 @@ namespace CodeJam
 			where TEnum : struct, Enum
 		{
 			if (!EnumHelper.IsDefined(value))
-				throw EnumCodeExceptions.ArgumentNotDefinedException(argName, value);
+				throw EnumCodeExceptions.ArgumentNotDefined(argName, value);
 		}
 
 		/// <summary>Asserts that all bits of the flags combination are defined.</summary>
@@ -51,7 +51,7 @@ namespace CodeJam
 			where TEnum : struct, Enum
 		{
 			if (!EnumHelper.AreFlagsDefined(argFlags))
-				throw EnumCodeExceptions.ArgumentNotDefinedException(argName, argFlags);
+				throw EnumCodeExceptions.ArgumentNotDefined(argName, argFlags);
 		}
 		#endregion
 

--- a/CodeJam.Main/Assertions/DebugUriCode.generated.cs
+++ b/CodeJam.Main/Assertions/DebugUriCode.generated.cs
@@ -29,7 +29,7 @@ namespace CodeJam
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
 		public static void IsWellFormedUri(
-			string uri,
+			[NotNull] string uri,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(uri, argName);
@@ -43,7 +43,7 @@ namespace CodeJam
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
 		public static void IsWellFormedAbsoluteUri(
-			string uri,
+			[NotNull] string uri,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(uri, argName);
@@ -57,7 +57,7 @@ namespace CodeJam
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
 		public static void IsWellFormedRelativeUri(
-			string uri,
+			[NotNull] string uri,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(uri, argName);

--- a/CodeJam.Main/Assertions/EnumCode.cs
+++ b/CodeJam.Main/Assertions/EnumCode.cs
@@ -25,7 +25,7 @@ namespace CodeJam
 			where TEnum : struct, Enum
 		{
 			if (!EnumHelper.IsDefined(value))
-				throw EnumCodeExceptions.ArgumentNotDefinedException(argName, value);
+				throw EnumCodeExceptions.ArgumentNotDefined(argName, value);
 		}
 
 		/// <summary>Asserts that all bits of the flags combination are defined.</summary>
@@ -40,7 +40,7 @@ namespace CodeJam
 			where TEnum : struct, Enum
 		{
 			if (!EnumHelper.AreFlagsDefined(argFlags))
-				throw EnumCodeExceptions.ArgumentNotDefinedException(argName, argFlags);
+				throw EnumCodeExceptions.ArgumentNotDefined(argName, argFlags);
 		}
 		#endregion
 

--- a/CodeJam.Main/Assertions/EnumCodeExceptions.cs
+++ b/CodeJam.Main/Assertions/EnumCodeExceptions.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelpers;
-using static CodeJam.Targeting.MethodImplOptionsEx;
 
 namespace CodeJam
 {
@@ -18,9 +17,8 @@ namespace CodeJam
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="value">The value.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentOutOfRangeException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
-		public static ArgumentOutOfRangeException ArgumentNotDefinedException<TEnum>(
+		[DebuggerHidden, NotNull, MustUseReturnValue]
+		public static ArgumentOutOfRangeException ArgumentNotDefined<TEnum>(
 			[NotNull, InvokerParameterName] string argumentName,
 			TEnum value)
 			where TEnum : struct, Enum
@@ -28,8 +26,9 @@ namespace CodeJam
 			BreakIfAttached();
 			var valueType = value.GetType();
 			return new ArgumentOutOfRangeException(
-				argumentName, value,
-				$"Unexpected value '{value}' of type '{valueType.FullName}'.")
+				argumentName,
+				value,
+				Invariant($"Unexpected value '{value}' of type '{valueType.FullName}'."))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 		#endregion
@@ -41,8 +40,7 @@ namespace CodeJam
 		/// <param name="value">The value.</param>
 		/// <param name="flag">The flag.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentFlagSet<TEnum>(
 			[NotNull, InvokerParameterName] string argumentName,
 			TEnum value, TEnum flag)
@@ -50,7 +48,7 @@ namespace CodeJam
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				$"The value of the {argumentName} argument ('{value}') should not include flag '{flag}'.",
+				Invariant($"The value of the {argumentName} argument ('{value}') should not include flag '{flag}'."),
 				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
@@ -61,8 +59,7 @@ namespace CodeJam
 		/// <param name="value">The value.</param>
 		/// <param name="flags">The bitwise combinations of the flags.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentAnyFlagUnset<TEnum>(
 			[NotNull, InvokerParameterName] string argumentName,
 			TEnum value, TEnum flags)
@@ -70,7 +67,7 @@ namespace CodeJam
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				$"The value of the {argumentName} argument ('{value}') should include flag '{flags}'.",
+				Invariant($"The value of the {argumentName} argument ('{value}') should include flag '{flags}'."),
 				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
@@ -81,8 +78,7 @@ namespace CodeJam
 		/// <param name="value">The value.</param>
 		/// <param name="flags">The bitwise combinations of the flags.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentAnyFlagSet<TEnum>(
 			[NotNull, InvokerParameterName] string argumentName,
 			TEnum value, TEnum flags)
@@ -90,7 +86,7 @@ namespace CodeJam
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				$"The value of the {argumentName} argument ('{value}') should not include any flag from '{flags}'.",
+				Invariant($"The value of the {argumentName} argument ('{value}') should not include any flag from '{flags}'."),
 				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
@@ -101,8 +97,7 @@ namespace CodeJam
 		/// <param name="value">The value.</param>
 		/// <param name="flag">The flag.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentFlagUnset<TEnum>(
 			[NotNull, InvokerParameterName] string argumentName,
 			TEnum value, TEnum flag)
@@ -110,7 +105,7 @@ namespace CodeJam
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				$"The value of the {argumentName} argument ('{value}') should include any flag from '{flag}'.",
+				Invariant($"The value of the {argumentName} argument ('{value}') should include any flag from '{flag}'."),
 				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}

--- a/CodeJam.Main/Assertions/UriCode.cs
+++ b/CodeJam.Main/Assertions/UriCode.cs
@@ -18,7 +18,7 @@ namespace CodeJam
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
 		public static void IsWellFormedUri(
-			string uri,
+			[NotNull] string uri,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(uri, argName);
@@ -32,7 +32,7 @@ namespace CodeJam
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
 		public static void IsWellFormedAbsoluteUri(
-			string uri,
+			[NotNull] string uri,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(uri, argName);
@@ -46,7 +46,7 @@ namespace CodeJam
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
 		public static void IsWellFormedRelativeUri(
-			string uri,
+			[NotNull] string uri,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(uri, argName);

--- a/CodeJam.Main/Assertions/UriCodeExceptions.cs
+++ b/CodeJam.Main/Assertions/UriCodeExceptions.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelpers;
-using static CodeJam.Targeting.MethodImplOptionsEx;
 
 namespace CodeJam
 {
@@ -18,14 +16,16 @@ namespace CodeJam
 		/// <param name="uri">The URI being checked.</param>
 		/// <param name="uriKind">Expected kind of the URI.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException" />.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static ArgumentException ArgumentNotWellFormedUri(
 			[NotNull, InvokerParameterName] string argumentName,
-			string uri, UriKind uriKind)
+			string uri,
+			UriKind uriKind)
 		{
 			BreakIfAttached();
-			return new ArgumentException(argumentName, $"Invalid {uriKind} URI '{uri}'.")
+			return new ArgumentException(
+				Invariant($"Invalid {uriKind}. URI '{uri}'."),
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 	}

--- a/CodeJam.Main/CodeJam.Main.csproj
+++ b/CodeJam.Main/CodeJam.Main.csproj
@@ -60,18 +60,18 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-		<PackageReference Include="Theraot.Core" Version="3.1.1" />
+		<PackageReference Include="Theraot.Core" Version="3.1.2" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
 		<Reference Include="System.ComponentModel.DataAnnotations" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-		<PackageReference Include="Theraot.Core" Version="3.1.1" />
+		<PackageReference Include="Theraot.Core" Version="3.1.2" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-		<PackageReference Include="Theraot.Core" Version="3.1.1" />
+		<PackageReference Include="Theraot.Core" Version="3.1.2" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-		<PackageReference Include="Theraot.Core" Version="3.1.1" />
+		<PackageReference Include="Theraot.Core" Version="3.1.2" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
@@ -88,7 +88,7 @@
 		<PackageReference Include="System.Reflection" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-		<PackageReference Include="Theraot.Core" Version="3.1.1" />
+		<PackageReference Include="Theraot.Core" Version="3.1.2" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
@@ -99,7 +99,7 @@
 		<PackageReference Include="System.Reflection" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-		<PackageReference Include="Theraot.Core" Version="3.1.1" />
+		<PackageReference Include="Theraot.Core" Version="3.1.2" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
@@ -112,7 +112,7 @@
 		<PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
 		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-		<PackageReference Include="Theraot.Core" Version="3.1.1" />
+		<PackageReference Include="Theraot.Core" Version="3.1.2" />
 	</ItemGroup>
 	<!-- #endregion -->
 

--- a/CodeJam.Main/IO/DebugIoCode.generated.cs
+++ b/CodeJam.Main/IO/DebugIoCode.generated.cs
@@ -9,7 +9,6 @@
 
 using static CodeJam.DebugCode;
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -52,7 +51,7 @@ namespace CodeJam.IO
 				throw IoCodeExceptions.ArgumentNotWellFormedAbsolutePath(argName, path);
 		}
 
-		/// <summary>Asserts that specified path is well-formed full path.</summary>
+		/// <summary>Asserts that specified path is well-formed relative path.</summary>
 		/// <param name="path">The path.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
@@ -80,18 +79,18 @@ namespace CodeJam.IO
 				throw IoCodeExceptions.ArgumentNotVolumeOrDirectoryPath(argName, path);
 		}
 
-		/// <summary>Asserts that specified path is well-formed simple name.</summary>
+		/// <summary>Asserts that specified path is well-formed file name.</summary>
 		/// <param name="path">The path.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[Conditional(DebugCondition), DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void IsWellFormedSimpleName(
+		public static void IsFileName(
 			[NotNull] string path,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(path, argName);
-			if (!PathHelpers.IsWellFormedSimpleName(path))
-				throw IoCodeExceptions.ArgumentNotSimpleName(argName, path);
+			if (!PathHelpers.IsFileName(path))
+				throw IoCodeExceptions.ArgumentNotFileName(argName, path);
 		}
 
 		#region IO path

--- a/CodeJam.Main/IO/IoCode.cs
+++ b/CodeJam.Main/IO/IoCode.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -41,7 +40,7 @@ namespace CodeJam.IO
 				throw IoCodeExceptions.ArgumentNotWellFormedAbsolutePath(argName, path);
 		}
 
-		/// <summary>Asserts that specified path is well-formed full path.</summary>
+		/// <summary>Asserts that specified path is well-formed relative path.</summary>
 		/// <param name="path">The path.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
@@ -69,18 +68,18 @@ namespace CodeJam.IO
 				throw IoCodeExceptions.ArgumentNotVolumeOrDirectoryPath(argName, path);
 		}
 
-		/// <summary>Asserts that specified path is well-formed simple name.</summary>
+		/// <summary>Asserts that specified path is well-formed file name.</summary>
 		/// <param name="path">The path.</param>
 		/// <param name="argName">Name of the argument.</param>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		[AssertionMethod]
-		public static void IsWellFormedSimpleName(
+		public static void IsFileName(
 			[NotNull] string path,
 			[NotNull, InvokerParameterName] string argName)
 		{
 			Code.NotNullNorEmpty(path, argName);
-			if (!PathHelpers.IsWellFormedSimpleName(path))
-				throw IoCodeExceptions.ArgumentNotSimpleName(argName, path);
+			if (!PathHelpers.IsFileName(path))
+				throw IoCodeExceptions.ArgumentNotFileName(argName, path);
 		}
 
 		#region IO path

--- a/CodeJam.Main/IO/IoCodeExceptions.cs
+++ b/CodeJam.Main/IO/IoCodeExceptions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.CompilerServices;
+
 using JetBrains.Annotations;
+
 using static CodeJam.Internal.CodeExceptionsHelpers;
-using static CodeJam.Targeting.MethodImplOptionsEx;
 
 namespace CodeJam.IO
 {
@@ -17,17 +17,16 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="path">The path being checked.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static ArgumentException ArgumentNotWellFormedPath(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string path)
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				argumentName,
-				$"The path '{path}' is not a valid absolute or not-rooted relative path.")
+				$"The path '{path}' is not a valid absolute or not-rooted relative path.",
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -35,17 +34,16 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="path">The path being checked.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static ArgumentException ArgumentNotWellFormedAbsolutePath(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string path)
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				argumentName,
-				$"The path '{path}' is not a valid full path.")
+				$"The path '{path}' is not a valid full path.",
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -53,35 +51,33 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="path">The path being checked.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static ArgumentException ArgumentRootedOrNotRelativePath(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string path)
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				argumentName,
-				$"The path '{path}' is not a valid not-rooted relative path.")
+				$"The path '{path}' is not a valid not-rooted relative path.",
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
-		/// <summary>Creates <see cref="ArgumentException"/> for invalid simple name.</summary>
+		/// <summary>Creates <see cref="ArgumentException"/> for invalid file name.</summary>
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="path">The path being checked.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
-		public static ArgumentException ArgumentNotSimpleName(
+		public static ArgumentException ArgumentNotFileName(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string path)
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				argumentName,
-				$"The path '{path}' is not a valid name of the file or a directory.")
+				$"The path '{path}' is not a valid name of the file or a directory.",
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
@@ -89,17 +85,16 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="path">The path being checked.</param>
 		/// <returns>Initialized instance of <see cref="ArgumentException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		public static ArgumentException ArgumentNotVolumeOrDirectoryPath(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string path)
 		{
 			BreakIfAttached();
 			return new ArgumentException(
-				argumentName,
-				$"The path '{path}' should end with volume or directory separator chars.")
+				$"The path '{path}' should end with volume or directory separator chars.",
+				argumentName)
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 		#endregion
@@ -109,8 +104,7 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="filePath">The file being checked.</param>
 		/// <returns>Initialized instance of <see cref="FileNotFoundException" />.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static FileNotFoundException ArgumentDirectoryExistsFileExpected(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string filePath)
@@ -125,8 +119,7 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="directoryPath">The directory being checked.</param>
 		/// <returns>Initialized instance of <see cref="DirectoryNotFoundException" />.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static DirectoryNotFoundException ArgumentFileExistsDirectoryExpected(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string directoryPath)
@@ -141,8 +134,7 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="filePath">The file being checked.</param>
 		/// <returns>Initialized instance of <see cref="FileNotFoundException" />.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static FileNotFoundException ArgumentFileNotFound(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string filePath)
@@ -156,8 +148,7 @@ namespace CodeJam.IO
 		/// <param name="argumentName">Name of the argument.</param>
 		/// <param name="directoryPath">The directory being checked.</param>
 		/// <returns>Initialized instance of <see cref="DirectoryNotFoundException" />.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static DirectoryNotFoundException ArgumentDirectoryNotFound(
 			[NotNull, InvokerParameterName] string argumentName,
 			[NotNull] string directoryPath)
@@ -171,9 +162,8 @@ namespace CodeJam.IO
 		/// <param name="messageFormat">The message format.</param>
 		/// <param name="args">The arguments.</param>
 		/// <returns>Initialized instance of <see cref="IOException"/>.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		[StringFormatMethod("messageFormat")]
-		[MustUseReturnValue]
 		// ReSharper disable once InconsistentNaming
 		public static IOException IOException(
 			[NotNull] string messageFormat,
@@ -181,15 +171,14 @@ namespace CodeJam.IO
 		{
 			BreakIfAttached();
 			return new IOException(
-				FormatExceptionMessage(messageFormat, args))
+				InvariantFormat(messageFormat, args))
 				.LogToCodeTraceSourceBeforeThrow();
 		}
 
 		/// <summary>Creates <see cref="IOException" /> for file that should not exist.</summary>
 		/// <param name="filePath">The file being checked.</param>
 		/// <returns>Initialized instance of <see cref="IOException" />.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static IOException FileExists([NotNull] string filePath)
 		{
 			BreakIfAttached();
@@ -200,8 +189,7 @@ namespace CodeJam.IO
 		/// <summary>Creates <see cref="IOException" /> for directory that should not exist.</summary>
 		/// <param name="directoryPath">The directory being checked.</param>
 		/// <returns>Initialized instance of <see cref="IOException" />.</returns>
-		[DebuggerHidden, NotNull, MethodImpl(AggressiveInlining)]
-		[MustUseReturnValue]
+		[DebuggerHidden, NotNull, MustUseReturnValue]
 		public static IOException DirectoryExists([NotNull] string directoryPath)
 		{
 			BreakIfAttached();

--- a/CodeJam.Main/IO/PathHelpers.cs
+++ b/CodeJam.Main/IO/PathHelpers.cs
@@ -97,16 +97,16 @@ namespace CodeJam.IO
 		/// <param name="path">The path.</param>
 		/// <returns><c>true</c> if the path ends with separator char; otherwise, <c>false</c>.</returns>
 		[Pure]
-		public static bool IsWellFormedSimpleName([NotNull] string path) =>
-			IsSimpleName(path) && IsWellFormedRelativePath(path);
+		public static bool IsWellFormedFileName([NotNull] string path) =>
+			IsFileName(path) && IsWellFormedRelativePath(path);
 
 		/// <summary>
-		/// Determines whether the path is a simple file or directory name.
+		/// Determines whether the path is a file or directory name.
 		/// </summary>
 		/// <param name="path">The path.</param>
-		/// <returns><c>true</c> if the path isa simple file or directory name; otherwise, <c>false</c>.</returns>
+		/// <returns><c>true</c> if the path is a file or directory name; otherwise, <c>false</c>.</returns>
 		[Pure]
-		public static bool IsSimpleName([NotNull] string path)
+		public static bool IsFileName([NotNull] string path)
 		{
 			Code.NotNullNorEmpty(path, nameof(path));
 


### PR DESCRIPTION
What's changed:
1. Minor performance-related tweaks. I've removed [MethodImpl(AggressiveInlining)] on slow path methods at it has no profit on modern runtimes.
2. [AssertionCondition] replaced with [ContractAnnotation]. Initially we've applied both as earlier Resharper versions have issues with ContractAnnotation annotations.
3. All `new ArgumentException()` calls pass arguments in valid order now. Some factories (IOCodeExceptions, as example) has message and argumentName args mixed up.
4. I've cleaned up reusable code in CodeExceptionsHelpers
5. Renamed PathHelpers/IoCode IsSimpleName() method to self-explanatory IsFileName().
6. GenericNotNull(). Enables not-null assertions on methods without `where T: class` constraint
7. NotEmpty(collection) renamed to NotNullNorEmpty(collection).