### PR TITLE
Adds configuration API and retry policy for temp data

### DIFF
--- a/Build/BuildScripts/CodeJam.AppVeyor.NUnit.Tests.ps1
+++ b/Build/BuildScripts/CodeJam.AppVeyor.NUnit.Tests.ps1
@@ -5,15 +5,40 @@ mkdir "$env:APPVEYOR_BUILD_FOLDER\_Results" -ErrorAction SilentlyContinue
 $wc = New-Object System.Net.WebClient
 
 #run .net tests
-$targetsDotNet = "net48;net472;net471;net47;net461;net45;net40;net35;net20" -split ";"
+$targetsDotNet = "net48;net472;net471;net47;net461;net45;net40" -split ";"
 foreach ($target in $targetsDotNet) {
 	$logFileName = "$env:APPVEYOR_BUILD_FOLDER\_Results\$($target)_nunit_results.xml"
 	$testAssemblies = (gci -include $include -r | `
 		where { $_.fullname -match "\\bin\\Release\\$($target)" } | `
 		select -ExpandProperty FullName)
 
+	echo ""
+	echo "=== $target ==="
 	echo "nunit3-console $testAssemblies --result=$logFileName"
 	&"nunit3-console" $testAssemblies "--result=$logFileName"
+	if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+
+	echo "UploadFile: https://ci.appveyor.com/api/testresults/nunit3/$env:APPVEYOR_JOB_ID from $logFileName"
+	$wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$env:APPVEYOR_JOB_ID", "$logFileName")
+	if ($LastExitCode -ne 0) {
+		echo "FAIL: UploadFile: https://ci.appveyor.com/api/testresults/nunit3/$env:APPVEYOR_JOB_ID from $logFileName"
+		$host.SetShouldExit($LastExitCode)
+	}
+}
+
+#run .net 2.x tests
+$targetsDotNet = "net35;net20" -split ";"
+foreach ($target in $targetsDotNet) {
+	$logFileName = "$env:APPVEYOR_BUILD_FOLDER\_Results\$($target)_nunit_results.xml"
+	$testAssemblies = (gci -include $include -r | `
+		where { $_.fullname -match "\\bin\\Release\\$($target)" } | `
+		select -ExpandProperty FullName)
+
+	echo ""
+	echo "=== $target ==="
+	# HACK: see https://github.com/appveyor/ci/issues/3412 for details
+	echo "nunit3-console $testAssemblies --result=$logFileName" "--framework=net-4.0"
+	&"nunit3-console" $testAssemblies "--result=$logFileName" "--framework=net-4.0"
 	if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 	echo "UploadFile: https://ci.appveyor.com/api/testresults/nunit3/$env:APPVEYOR_JOB_ID from $logFileName"
@@ -32,6 +57,8 @@ foreach ($target in $targetsDotNetCore) {
 		where { $_.fullname -match "\\bin\\Release\\$($target)" } | `
 		select -ExpandProperty FullName)
 
+	echo ""
+	echo "=== $target ==="
 	echo "dotnet vstest $testAssemblies --logger:'trx;LogFileName=$logFileName'"
 	dotnet vstest $testAssemblies --logger:"trx;LogFileName=$logFileName"
 	if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }

--- a/CodeJam.Blocks.Tests/CodeJam.Blocks.Tests.csproj
+++ b/CodeJam.Blocks.Tests/CodeJam.Blocks.Tests.csproj
@@ -25,7 +25,7 @@
 		<!-- NUnit v3.11 is the last version supporting .NET 2.0 -->
 		<PackageReference Include="NUnit" Version="[3.11.0]" />
 		<PackageReference Include="NUnit3TestAdapter" Version="[3.15.1]" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[16.2.0]" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
 		<!-- NUnit v3.9 is the last version supporting .NET Core 1.0 -->

--- a/CodeJam.Blocks/Services/ServiceProviderHelper.cs
+++ b/CodeJam.Blocks/Services/ServiceProviderHelper.cs
@@ -91,10 +91,15 @@ namespace CodeJam.Services
 		{
 			Code.NotNull(publisher, nameof(publisher));
 			Code.NotNull(instanceFactory, nameof(instanceFactory));
-			// DONTTOUCH: for valid overload resolution (fails on net35).
 
+			// DONTTOUCH: for valid overload resolution (fails on net35).
+#if NET40_OR_GREATER || TARGETS_NETSTANDARD || TARGETS_NETCOREAPP
 			// ReSharper disable once RedundantCast
-			return publisher.Publish(typeof(T), instanceFactory);
+			return publisher.Publish(typeof(T), (Func<IServicePublisher, object>)instanceFactory);
+#else
+			// Hack for CS0030 Cannot convert type 'System.Func<CodeJam.Services.IServicePublisher, T>' to 'System.Func<CodeJam.Services.IServicePublisher, object>'
+			return publisher.Publish(typeof(T), new Func<IServicePublisher, object>(sp => instanceFactory(sp)));
+#endif
 		}
 	}
 }

--- a/CodeJam.Experimental.Tests/UseCases/EnumCodeUseCases.cs
+++ b/CodeJam.Experimental.Tests/UseCases/EnumCodeUseCases.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
 
-using CodeJam.Internal;
-
 using JetBrains.Annotations;
 
 using NUnit.Framework;
@@ -17,16 +15,13 @@ namespace CodeJam.UseCases.EnumHelperSamples
 	public class EnumCodeUseCases
 	{
 		#region Test helpers
-		private bool? _breakOnException;
 		private CultureInfo _previousCulture;
 
 		[OneTimeSetUp]
 		[UsedImplicitly]
 		public void SetUp()
 		{
-			_breakOnException = CodeExceptionsHelper.BreakOnException;
 			_previousCulture = Thread.CurrentThread.CurrentUICulture;
-			CodeExceptionsHelper.BreakOnException = false;
 			Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
 		}
 
@@ -34,9 +29,7 @@ namespace CodeJam.UseCases.EnumHelperSamples
 		[UsedImplicitly]
 		public void TearDown()
 		{
-			Code.NotNull(_breakOnException, nameof(_breakOnException));
 			Code.NotNull(_previousCulture, nameof(_previousCulture));
-			CodeExceptionsHelper.BreakOnException = _breakOnException.GetValueOrDefault();
 			Thread.CurrentThread.CurrentUICulture = _previousCulture;
 		}
 		#endregion

--- a/CodeJam.Main.Tests/Assertions/CodeTests.cs
+++ b/CodeJam.Main.Tests/Assertions/CodeTests.cs
@@ -25,7 +25,7 @@ namespace CodeJam.Assertions
 			{
 				TraceOutputOptions = TraceOptions.None
 			};
-			var ts = CodeExceptionsHelper.CodeTraceSource;
+			var ts = Configuration.CodeTraceSource;
 			var logLevel = ts.Switch.Level;
 			try
 			{

--- a/CodeJam.Main.Tests/CodeJam.Main.Tests.csproj
+++ b/CodeJam.Main.Tests/CodeJam.Main.Tests.csproj
@@ -26,7 +26,7 @@
 		<!-- NUnit v3.11 is the last version supporting .NET 2.0 -->
 		<PackageReference Include="NUnit" Version="[3.11.0]" />
 		<PackageReference Include="NUnit3TestAdapter" Version="[3.15.1]" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[16.2.0]" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
 		<!-- NUnit v3.9 is the last version supporting .NET Core 1.0 -->

--- a/CodeJam.Main.Tests/IO/TempDataTests.cs
+++ b/CodeJam.Main.Tests/IO/TempDataTests.cs
@@ -142,9 +142,9 @@ namespace CodeJam.IO
 					Assert.AreEqual(disposeCallCount, 2);
 
 				}
+				Assert.AreEqual(disposeCallCount, 2);
 				Assert.IsFalse(Directory.Exists(dirPath), "Directory should NOT exist");
 				Assert.IsFalse(File.Exists(nestedFile), "File should NOT exist");
-				Assert.AreEqual(disposeCallCount, 2);
 			}
 			finally
 			{

--- a/CodeJam.Main.Tests/IO/TempDataTests.cs
+++ b/CodeJam.Main.Tests/IO/TempDataTests.cs
@@ -2,18 +2,31 @@
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
+
+using CodeJam.Internal;
 
 using NUnit.Framework;
 
 namespace CodeJam.IO
 {
 	[TestFixture(Category = "IO")]
+	[NonParallelizable]
 	public class TempDataTests
 	{
 		#region Test helpers
 		private static void AssertDisposed<T>(Func<T> memberCallback) =>
 			Assert.Throws<ObjectDisposedException>(() => memberCallback());
-		#endregion
+
+		// DONTTOUCH: DO NOT use [OneTimeSetUp] here as some tests may override the retry policy
+		[SetUp]
+		public static void SetupDisableTempDataRetry() =>
+			Configuration.SetTempDataRetryCallback(a => a());
+
+		// DONTTOUCH: DO NOT use [OneTimeTearDown] here as some tests may override the retry policy
+		[TearDown]
+		public static void TearDownRestoreTempDataRetry() =>
+			Configuration.SetTempDataRetryCallback(null);
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		private static string CreateAndLeakTempDir(string s)
@@ -26,6 +39,7 @@ namespace CodeJam.IO
 			GC.KeepAlive(dir2);
 			return dir2Path;
 		}
+		#endregion
 
 		[Test]
 		public void TestDirectory()
@@ -96,6 +110,46 @@ namespace CodeJam.IO
 			Assert.IsFalse(Directory.Exists(dirPath), "Directory should NOT exist");
 			Assert.IsFalse(Directory.Exists(nestedDir), "Directory should NOT exist");
 			Assert.IsFalse(File.Exists(nestedFile), "File should NOT exist");
+		}
+
+		[Test]
+		public void TestRetryPolicy()
+		{
+			int disposeCallCount = 0;
+			try
+			{
+				Configuration.SetTempDataRetryCallback(
+					a =>
+					{
+						Interlocked.Increment(ref disposeCallCount);
+						a();
+					});
+
+				string dirPath;
+				string nestedFile;
+				using (var dir = TempData.CreateDirectory())
+				{
+					dirPath = dir.Path;
+					nestedFile = Path.Combine(dirPath, "test.tmp");
+
+					using (File.Create(nestedFile))
+					{
+						Assert.Throws<IOException>(() => dir.Dispose());
+						Assert.AreEqual(disposeCallCount, 1);
+					}
+
+					Assert.DoesNotThrow(() => dir.Dispose());
+					Assert.AreEqual(disposeCallCount, 2);
+
+				}
+				Assert.IsFalse(Directory.Exists(dirPath), "Directory should NOT exist");
+				Assert.IsFalse(File.Exists(nestedFile), "File should NOT exist");
+				Assert.AreEqual(disposeCallCount, 2);
+			}
+			finally
+			{
+				Configuration.SetTempDataRetryCallback(null);
+			}
 		}
 
 		[Test]

--- a/CodeJam.Main.Tests/TestTools.cs
+++ b/CodeJam.Main.Tests/TestTools.cs
@@ -16,8 +16,8 @@ namespace CodeJam
 	public static class TestTools
 	{
 		[NotNull]
-		public static Random GetTestRandom() =>
-			GetTestRandom(new Random().Next());
+		public static Random GetTestRandom([CallerMemberName] string memberName = "") =>
+			GetTestRandom(new Random().Next(), memberName);
 
 		[NotNull]
 		[MethodImpl(MethodImplOptions.NoInlining)]

--- a/CodeJam.Main.Tests/Threading/TimeoutHelperTests.cs
+++ b/CodeJam.Main.Tests/Threading/TimeoutHelperTests.cs
@@ -2,6 +2,8 @@
 
 using NUnit.Framework;
 
+using Range = CodeJam.Ranges.Range;
+
 namespace CodeJam.Threading
 {
 	[TestFixture]
@@ -73,6 +75,23 @@ namespace CodeJam.Threading
 			Assert.AreEqual(dMinus1.AdjustTimeout(TimeSpan.Zero, infiniteIfDefault), TimeoutHelper.InfiniteTimeSpan);
 			Assert.AreEqual(dMinus1.AdjustTimeout(d1, infiniteIfDefault), d1);
 			Assert.AreEqual(dMinus1.AdjustTimeout(dMinus1, infiniteIfDefault), TimeoutHelper.InfiniteTimeSpan);
+		}
+
+		[TestCase(0, 1)]
+		[TestCase(1, 1)]
+		[TestCase(4, 8)]
+		[TestCase(6, 32)]
+		[TestCase(8, 60)]
+		[TestCase(10, 60)]
+		[TestCase(100, 60)]
+		public void TestBackoff(int retry, int resultSeconds)
+		{
+			var delay = TimeSpan.FromSeconds(1);
+			var max = TimeSpan.FromMinutes(1);
+			var timeoutSeconds = TimeoutHelper.ExponentialBackoffTimeout(retry, delay, max).TotalSeconds;
+			var range = Range.Create(resultSeconds * 0.8, resultSeconds * 1.2);
+
+			Assert.IsTrue(range.Contains(timeoutSeconds), $"{range} does not contain {timeoutSeconds}");
 		}
 	}
 }

--- a/CodeJam.Main.Tests/Threading/TimeoutHelperTests.cs
+++ b/CodeJam.Main.Tests/Threading/TimeoutHelperTests.cs
@@ -2,8 +2,6 @@
 
 using NUnit.Framework;
 
-using Range = CodeJam.Ranges.Range;
-
 namespace CodeJam.Threading
 {
 	[TestFixture]
@@ -89,9 +87,8 @@ namespace CodeJam.Threading
 			var delay = TimeSpan.FromSeconds(1);
 			var max = TimeSpan.FromMinutes(1);
 			var timeoutSeconds = TimeoutHelper.ExponentialBackoffTimeout(retry, delay, max).TotalSeconds;
-			var range = Range.Create(resultSeconds * 0.8, resultSeconds * 1.2);
 
-			Assert.IsTrue(range.Contains(timeoutSeconds), $"{range} does not contain {timeoutSeconds}");
+			Assert.That(timeoutSeconds, Is.InRange(resultSeconds * 0.8, resultSeconds * 1.2));
 		}
 	}
 }

--- a/CodeJam.Main/Assertions/CodeExceptions.cs
+++ b/CodeJam.Main/Assertions/CodeExceptions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 
+using CodeJam.Internal;
+
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelper;

--- a/CodeJam.Main/Assertions/CodeExceptionsHelper.cs
+++ b/CodeJam.Main/Assertions/CodeExceptionsHelper.cs
@@ -17,18 +17,11 @@ namespace CodeJam.Internal
 	public static class CodeExceptionsHelper
 	{
 		#region Setup
-		/// <summary>
-		/// If true, breaks execution if debugger is attached and assertion is failed.
-		/// Enabled by default.
-		/// </summary>
-		/// <value><c>true</c> if the execution will break on exception creation; otherwise, <c>false</c>.</value>
-		public static bool BreakOnException { get; set; } = true;
-
-		/// <summary>BreaksExecution if debugger attached.</summary>
+		/// <summary>Breaks execution if debugger attached.</summary>
 		[DebuggerHidden, MethodImpl(AggressiveInlining)]
 		public static void BreakIfAttached()
 		{
-			if (BreakOnException && Debugger.IsAttached)
+			if (Configuration.BreakOnFailedAssertions && Debugger.IsAttached)
 				Debugger.Break();
 		}
 		#endregion
@@ -59,75 +52,6 @@ namespace CodeJam.Internal
 		internal static string Invariant([NotNull] FormattableString messageFormat) =>
 			messageFormat.ToString(CultureInfo.InvariantCulture);
 
-		#endregion
-
-		#region Logging
-		/// <summary>Returns trace source for code exceptions.</summary>
-		/// <value>The code trace source.</value>
-		[NotNull]
-		public static TraceSource CodeTraceSource => _codeTraceSource.Value;
-
-		[NotNull, ItemNotNull]
-		private static readonly Lazy<TraceSource> _codeTraceSource = new Lazy<TraceSource>(
-			() => CreateTraceSource(typeof(Code).Namespace + "." + nameof(CodeTraceSource)));
-
-		[NotNull]
-		private static TraceSource CreateTraceSource([NotNull] string sourceName) =>
-			new TraceSource(sourceName) { Switch = { Level = SourceLevels.Warning } };
-
-		private static readonly string _assertionFailedMessageWithStack =
-			"Assertion failed: {0}" + Environment.NewLine + "{1}";
-
-		private static readonly string _exceptionCaughtMessage = "Exception caught safely: {0}";
-		private static readonly string _exceptionSwallowedMessage = "Exception swallowed: {0}";
-
-		/// <summary>Logs the exception that will be thrown to the <see cref="CodeTraceSource"/>.</summary>
-		/// <typeparam name="TException">The type of the exception.</typeparam>
-		/// <param name="exception">The exception.</param>
-		/// <returns>The original exception.</returns>
-		[NotNull, MustUseReturnValue]
-		public static TException LogToCodeTraceSourceBeforeThrow<TException>([NotNull] this TException exception)
-			where TException : Exception
-		{
-			CodeTraceSource.TraceEvent(
-				TraceEventType.Verbose,
-				0,
-				_assertionFailedMessageWithStack,
-				exception,
-				Environment.StackTrace);
-
-			return exception;
-		}
-
-		/// <summary>
-		/// Logs the caught exception to the <see cref="CodeTraceSource" />.
-		/// </summary>
-		/// <typeparam name="TException">The type of the exception.</typeparam>
-		/// <param name="exception">The exception.</param>
-		/// <param name="safe">If set to <c>true</c> the exception is expected and can be ignored safely.</param>
-		/// <returns>
-		/// The original exception.
-		/// </returns>
-		[NotNull]
-		public static TException LogToCodeTraceSourceOnCatch<TException>([NotNull] this TException exception, bool safe)
-			where TException : Exception
-		{
-			if (safe)
-				CodeTraceSource.TraceEvent(
-					TraceEventType.Verbose,
-					0,
-					_exceptionCaughtMessage,
-					exception);
-
-			else
-				CodeTraceSource.TraceEvent(
-					TraceEventType.Warning,
-					0,
-					_exceptionSwallowedMessage,
-					exception);
-
-			return exception;
-		}
 		#endregion
 	}
 }

--- a/CodeJam.Main/Assertions/EnumCodeExceptions.cs
+++ b/CodeJam.Main/Assertions/EnumCodeExceptions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 
+using CodeJam.Internal;
+
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelper;

--- a/CodeJam.Main/Assertions/UriCodeExceptions.cs
+++ b/CodeJam.Main/Assertions/UriCodeExceptions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 
+using CodeJam.Internal;
+
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelper;

--- a/CodeJam.Main/Configuration.cs
+++ b/CodeJam.Main/Configuration.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using CodeJam.Threading;
+
+using JetBrains.Annotations;
+
+// ReSharper disable once CheckNamespace
+namespace CodeJam.Internal
+{
+	/// <summary>
+	/// Helper class for overriding default library behaviour.
+	/// </summary>
+	[PublicAPI]
+	public static class Configuration
+	{
+		#region Exceptions
+		/// <summary>
+		/// If true, breaks execution if debugger is attached and assertion is failed.
+		/// Enabled by default.
+		/// </summary>
+		/// <value><c>true</c> if the execution will break on exception creation; otherwise, <c>false</c>.</value>
+		public static bool BreakOnFailedAssertions { get; set; } = true;
+		#endregion
+
+		#region Logging
+		[NotNull, ItemNotNull]
+		private static readonly Lazy<TraceSource> _codeTraceSource = new Lazy<TraceSource>(
+			() => CreateTraceSource(typeof(Code).Namespace + "." + nameof(CodeTraceSource)));
+
+		[NotNull]
+		private static TraceSource CreateTraceSource([NotNull] string sourceName) =>
+			new TraceSource(sourceName) { Switch = { Level = SourceLevels.Information } };
+
+		[CanBeNull]
+		private static TraceSource _customCodeTraceSource;
+
+		/// <summary>
+		/// Sets custom trace source for code exceptions.
+		/// Pass <c>null</c> to restore default behaviour.
+		/// </summary>
+		/// <param name="codeTraceSource">The custom trace source.</param>
+		public static void SetCodeTraceSource([CanBeNull]TraceSource codeTraceSource) =>
+			_customCodeTraceSource = codeTraceSource;
+
+		/// <summary>Returns trace source for code exceptions.</summary>
+		/// <value>The code trace source.</value>
+		[NotNull]
+		public static TraceSource CodeTraceSource => _customCodeTraceSource ?? _codeTraceSource.Value;
+
+		private static readonly string _assertionFailedMessageWithStack =
+			"Assertion failed: {0}" + Environment.NewLine + "{1}";
+
+		private static readonly string _exceptionCaughtMessage = "Exception caught safely: {0}";
+
+		private static readonly string _exceptionSwallowedMessage = "Exception swallowed: {0}";
+
+		/// <summary>Logs the exception that will be thrown to the <see cref="CodeTraceSource"/>.</summary>
+		/// <typeparam name="TException">The type of the exception.</typeparam>
+		/// <param name="exception">The exception.</param>
+		/// <returns>The original exception.</returns>
+		[NotNull, MustUseReturnValue]
+		public static TException LogToCodeTraceSourceBeforeThrow<TException>([NotNull] this TException exception)
+			where TException : Exception
+		{
+			CodeTraceSource.TraceEvent(
+				TraceEventType.Verbose,
+				0,
+				_assertionFailedMessageWithStack,
+				exception,
+				Environment.StackTrace);
+
+			return exception;
+		}
+
+		/// <summary>
+		/// Logs the caught exception to the <see cref="CodeTraceSource" />.
+		/// </summary>
+		/// <typeparam name="TException">The type of the exception.</typeparam>
+		/// <param name="exception">The exception.</param>
+		/// <param name="safe">If set to <c>true</c> the exception is expected and can be ignored safely.</param>
+		/// <returns>
+		/// The original exception.
+		/// </returns>
+		[NotNull]
+		public static TException LogToCodeTraceSourceOnCatch<TException>([NotNull] this TException exception, bool safe)
+			where TException : Exception
+		{
+			if (safe)
+				CodeTraceSource.TraceEvent(
+					TraceEventType.Verbose,
+					0,
+					_exceptionCaughtMessage,
+					exception);
+
+			else
+				CodeTraceSource.TraceEvent(
+					TraceEventType.Warning,
+					0,
+					_exceptionSwallowedMessage,
+					exception);
+
+			return exception;
+		}
+		#endregion
+
+		#region TempDataRetry
+		private static void TempDataRetry(Action callback)
+		{
+			if (callback == null)
+				throw new ArgumentNullException(nameof(callback));
+
+			List<Exception> exceptions = null;
+			var throttleDelay = TimeSpan.FromMilliseconds(100);
+			var maxThrottleDelay = TimeSpan.FromSeconds(10);
+
+			for (var i = 0; i < 5; i++)
+			{
+				try
+				{
+					callback();
+					break;
+				}
+				catch (IOException ex)
+				{
+					ex.LogToCodeTraceSourceOnCatch(true);
+					exceptions ??= new List<Exception>();
+					exceptions.Add(ex);
+
+					var delay = TimeoutHelper.ExponentialBackoffTimeout(i + 1, throttleDelay, maxThrottleDelay);
+
+#if TARGETS_NET || NETSTANDARD20_OR_GREATER || TARGETS_NETCOREAPP
+					Thread.Sleep(delay);
+#else
+					Task.Delay(delay).Wait();
+#endif
+				}
+			}
+
+			if (exceptions != null)
+			{
+				var exception = new AggregateException(exceptions);
+				throw exception.LogToCodeTraceSourceBeforeThrow();
+			}
+		}
+
+		[NotNull]
+		private static readonly Action<Action> _tempDataRetryCallback = TempDataRetry;
+
+		[CanBeNull]
+		private static Action<Action> _customTempDataRetryCallback;
+
+		/// <summary>
+		/// Sets the custom retry callback for <see cref="CodeJam.IO.TempData"/> disposal.
+		/// Pass <c>null</c> to restore default behaviour.
+		/// </summary>
+		/// <param name="tempDataRetryCallback">The retry callback.</param>
+		public static void SetTempDataRetryCallback([CanBeNull]Action<Action> tempDataRetryCallback) =>
+			_customTempDataRetryCallback = tempDataRetryCallback;
+
+		/// <summary>Returns retry callback for <see cref="CodeJam.IO.TempData"/> disposal.</summary>
+		/// <value>The retry callback for <see cref="CodeJam.IO.TempData"/> disposal.</value>
+		public static Action<Action> TempDataRetryCallback => _customTempDataRetryCallback ?? _tempDataRetryCallback;
+
+		#endregion
+	}
+}

--- a/CodeJam.Main/Dates/DateTimeCodeExceptions.cs
+++ b/CodeJam.Main/Dates/DateTimeCodeExceptions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 
+using CodeJam.Internal;
+
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelper;

--- a/CodeJam.Main/IO/IoCodeExceptions.cs
+++ b/CodeJam.Main/IO/IoCodeExceptions.cs
@@ -2,6 +2,8 @@
 using System.Diagnostics;
 using System.IO;
 
+using CodeJam.Internal;
+
 using JetBrains.Annotations;
 
 using static CodeJam.Internal.CodeExceptionsHelper;

--- a/CodeJam.sln.DotSettings
+++ b/CodeJam.sln.DotSettings
@@ -388,6 +388,7 @@ Code.NotNull($EXPR$, $NAME$);</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appveyor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=arg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=async/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=backoff/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Backported/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BADCODE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BASEDON/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This PR attempts to add extensibility/configuration API.

Scenario: as a customer of the library I wish to be able to override default behavior for some features. Candidates are: logging, retry policy for temp data and so on.

Previously we had configuration API for code assertions only (see `CodeExceptionsHelper`). This PR adds TempData retry policy configuration. In future, there may be more extensibility points.

As a starting point, I've added single `CodeJam.Internal.Configuration` class that contains all configurable features. Personally, I do not like current design as it puts a lot of uncoupled code into single class. I cannot find a good alternative, so feedback is welcome!

As addition, I've added TimeoutHelper.ExponentialBackoffTimeout method that is used by default temp data retry policy implementation.