### PR TITLE
Add TypeConverter with ability to convert from string to ConnectionStringBase

### DIFF
--- a/CodeJam.Main.Tests/ConnectionStrings/ConnectionStringTests.cs
+++ b/CodeJam.Main.Tests/ConnectionStrings/ConnectionStringTests.cs
@@ -253,5 +253,20 @@ BooleanValue=true;
 			IsFalse(x.EquivalentTo(x2));
 			AreNotEqual(x.ToArray(), x2.ToArray());
 		}
+
+		[Test]
+		public void TypeConverter_Ok()
+		{
+			var converter = TypeDescriptor.GetConverter(typeof (DerivedConnectionString));
+
+			// The test simulates the behavior of the
+			// Microsoft.Extensions.Configuration.ConfigurationBinder.TryConvertValue method
+			IsTrue(converter.CanConvertFrom(typeof(string)));
+			var cs = converter.ConvertFromInvariantString("RequiredValue=Req;OptionalValue=Opt") as DerivedConnectionString;
+
+			IsNotNull(cs);
+			AreEqual("Req", cs?.RequiredValue);
+			AreEqual("Opt", cs?.OptionalValue);
+		}
 	}
 }

--- a/CodeJam.Main/ConnectionStrings/ConnectionStringBase.ConnectionStringBaseTypeConverter.cs
+++ b/CodeJam.Main/ConnectionStrings/ConnectionStringBase.ConnectionStringBaseTypeConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq.Expressions;
+
+using CodeJam.Reflection;
+
+namespace CodeJam.ConnectionStrings
+{
+	[TypeConverter(typeof(ConnectionStringBaseTypeConverter))]
+	public abstract partial class ConnectionStringBase
+	{
+		/// <inheritdoc />
+		public class ConnectionStringBaseTypeConverter : TypeConverter
+		{
+			private static readonly ConcurrentDictionary<Type, Func<string, object>> _creators = new();
+
+			private readonly Type _callingType;
+
+			public ConnectionStringBaseTypeConverter(Type callingType)
+			{
+				Code.AssertArgument(
+					callingType.IsAssignableTo<ConnectionStringBase>(), nameof(callingType),
+					$"To be used with this converter, the type must be inherited from {nameof(ConnectionStringBase)}");
+				_callingType = callingType;
+			}
+
+			private Func<string, object> GetCreator() => _creators.GetOrAdd(
+				_callingType, ct =>
+				{
+					var ctor = ct.GetConstructor(new[] { typeof(string) });
+					Code.AssertState(ctor != null, $"The type {ct} must have a constructor with a single argument of type string");
+					var srcPrm = Expression.Parameter(typeof(string), "source");
+					var lambda = Expression.Lambda<Func<string, object>>(Expression.New(ctor, srcPrm), srcPrm);
+					return lambda.Compile();
+				});
+
+			#region Overrides of TypeConverter
+			/// <inheritdoc />
+			public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+				=> base.CanConvertFrom(context, sourceType) || sourceType == typeof(string);
+
+			/// <inheritdoc />
+			public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+				=> value is string str ? GetCreator()(str) : base.ConvertFrom(context, culture, value);
+			#endregion
+		}
+	}
+}

--- a/CodeJam.Main/ConnectionStrings/ConnectionStringBase.cs
+++ b/CodeJam.Main/ConnectionStrings/ConnectionStringBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;

--- a/CodeJam.Main/ConnectionStrings/ConnectionStringBase.cs
+++ b/CodeJam.Main/ConnectionStrings/ConnectionStringBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -17,50 +18,11 @@ namespace CodeJam.ConnectionStrings
 	[PublicAPI]
 	public abstract partial class ConnectionStringBase : IDictionary<string, object>
 	{
-		/// <summary>
-		/// Descriptor for connection string keyword
-		/// </summary>
-		[PublicAPI]
-		protected class KeywordDescriptor
-		{
-			/// <summary>
-			/// Initializes a new instance of the <see cref="KeywordDescriptor"/> class.
-			/// </summary>
-			public KeywordDescriptor(string name, Type valueType, bool isRequired, bool isBrowsable)
-			{
-				Name = name;
-				ValueType = valueType;
-				IsRequired = isRequired;
-				IsBrowsable = isBrowsable;
-			}
-
-			/// <summary>
-			/// Gets the keyword name.
-			/// </summary>
-			public string Name { get; }
-
-			/// <summary>
-			/// Gets expected type of the keyword value.
-			/// </summary>
-			public Type ValueType { get; }
-
-			/// <summary>
-			/// Gets a value indicating whether this keyword is a mandatory keyword.
-			/// </summary>
-			public bool IsRequired { get; }
-
-			/// <summary>
-			/// Gets a value indicating whether this keyword is browsable (safe to log / display).
-			/// </summary>
-			public bool IsBrowsable { get; }
-		}
-
 		private readonly StringBuilderWrapper _wrapper;
 
 		/// <summary>Initializes a new instance of the <see cref="ConnectionStringBase" /> class.</summary>
 		/// <param name="connectionString">The connection string.</param>
-		protected ConnectionStringBase(string? connectionString)
-			=> _wrapper = new StringBuilderWrapper(connectionString, GetType());
+		protected ConnectionStringBase(string? connectionString) => _wrapper = new(connectionString, GetType());
 
 		/// <summary>
 		/// Gets all supported keywords for current connection.
@@ -259,6 +221,46 @@ namespace CodeJam.ConnectionStrings
 		#region Overrides of Object
 		/// <inheritdoc />
 		public override string ToString() => _wrapper.ToString();
+		#endregion
+
+		#region KeywordDescriptor class
+		/// <summary>
+		/// Descriptor for connection string keyword
+		/// </summary>
+		[PublicAPI]
+		protected class KeywordDescriptor
+		{
+			/// <summary>
+			/// Initializes a new instance of the <see cref="KeywordDescriptor"/> class.
+			/// </summary>
+			public KeywordDescriptor(string name, Type valueType, bool isRequired, bool isBrowsable)
+			{
+				Name = name;
+				ValueType = valueType;
+				IsRequired = isRequired;
+				IsBrowsable = isBrowsable;
+			}
+
+			/// <summary>
+			/// Gets the keyword name.
+			/// </summary>
+			public string Name { get; }
+
+			/// <summary>
+			/// Gets expected type of the keyword value.
+			/// </summary>
+			public Type ValueType { get; }
+
+			/// <summary>
+			/// Gets a value indicating whether this keyword is a mandatory keyword.
+			/// </summary>
+			public bool IsRequired { get; }
+
+			/// <summary>
+			/// Gets a value indicating whether this keyword is browsable (safe to log / display).
+			/// </summary>
+			public bool IsBrowsable { get; }
+		}
 		#endregion
 	}
 }

--- a/CodeJam.Main/Readme.txt
+++ b/CodeJam.Main/Readme.txt
@@ -1,5 +1,9 @@
-﻿CodeJam 4.0.2 Release Notes
+﻿CodeJam 4.0.3 Release Notes
 ---------------------------
+What's new in 4.0.3
+-------------------
+* Add TypeConverter with ability to convert from string to ConnectionStringBase
+* Remove the IsAssignableTo method from .NET 5+, since a full analogue appeared there
 
 What's new in 4.0.2
 -------------------

--- a/CodeJam.Main/Reflection/ReflectionExtensions.cs
+++ b/CodeJam.Main/Reflection/ReflectionExtensions.cs
@@ -708,8 +708,14 @@ namespace CodeJam.Reflection
 		///   <c>true</c> if instance of current type can be assigned to instance of <typeparamref name="T"/>; otherwise, <c>false</c>.
 		/// </returns>
 		[Pure, System.Diagnostics.Contracts.Pure]
-		public static bool IsAssignableTo<T>(this Type? type) => typeof(T).IsAssignableFrom(type);
+		public static bool IsAssignableTo<T>([NotNullWhen(true)] this Type? type) =>
+#if NET5_0_OR_GREATER
+			type != null && type.IsAssignableTo(typeof (T)); // IsAssignableTo is intrinsic in .NET 5+
+#else
+			typeof(T).IsAssignableFrom(type);
+#endif
 
+#if !NET5_0_OR_GREATER
 		/// <summary>
 		/// Determines whether instance of current type can be assigned to instance of <paramref name="targetType"/>.
 		/// </summary>
@@ -719,11 +725,12 @@ namespace CodeJam.Reflection
 		///   <c>true</c> if instance of current type can be assigned to instance of <paramref name="targetType"/>; otherwise, <c>false</c>.
 		/// </returns>
 		[Pure, System.Diagnostics.Contracts.Pure]
-		public static bool IsAssignableTo(this Type? type, Type targetType)
+		public static bool IsAssignableTo([NotNullWhen(true)] this Type? type, Type targetType)
 		{
 			Code.NotNull(targetType, nameof(targetType));
 
 			return targetType.IsAssignableFrom(type);
 		}
+#endif
 	}
 }


### PR DESCRIPTION
* Add TypeConverter with ability to convert from string to ConnectionStringBase.
* Remove the IsAssignableTo method from .NET 5+, since a full analogue appeared there.