### PR TITLE
Fix for ReaderWriterLockSlimExtensions

### DIFF
--- a/CodeJam.Main.Tests/Threading/ReaderWriterLockSlimTests.cs
+++ b/CodeJam.Main.Tests/Threading/ReaderWriterLockSlimTests.cs
@@ -18,7 +18,7 @@ namespace CodeJam.Threading
 			using (rwl.GetReadLock())
 				Assert.IsTrue(rwl.IsReadLockHeld);
 
-			Assert.That(rwl.IsReadLockHeld, Is.False);
+			Assert.IsFalse(rwl.IsReadLockHeld);
 		}
 
 		[Test]

--- a/CodeJam.Main.Tests/Threading/ReaderWriterLockSlimTests.cs
+++ b/CodeJam.Main.Tests/Threading/ReaderWriterLockSlimTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading;
+
+using NUnit.Framework;
+
+namespace CodeJam.Threading
+{
+	[TestFixture]
+	public sealed class ReaderWriterLockSlimTests
+	{
+		[Test]
+		public void GetReadLock_Release()
+		{
+			var rwl = new ReaderWriterLockSlim();
+
+			Assert.IsFalse(rwl.IsReadLockHeld);
+
+			using (rwl.GetReadLock())
+				Assert.IsTrue(rwl.IsReadLockHeld);
+
+			Assert.That(rwl.IsReadLockHeld, Is.False);
+		}
+
+		[Test]
+		public void GetWriteLock_Release()
+		{
+			var rwl = new ReaderWriterLockSlim();
+
+			Assert.IsFalse(rwl.IsWriteLockHeld);
+
+			using (rwl.GetWriteLock())
+				Assert.IsTrue(rwl.IsWriteLockHeld);
+
+			Assert.IsFalse(rwl.IsWriteLockHeld);
+		}
+
+		[Test]
+		public void GetUpgradeableReadLock_Release()
+		{
+			var rwl = new ReaderWriterLockSlim();
+
+			Assert.IsFalse(rwl.IsUpgradeableReadLockHeld);
+
+			using (rwl.GetUpgradeableReadLock())
+				Assert.IsTrue(rwl.IsUpgradeableReadLockHeld);
+
+			Assert.IsFalse(rwl.IsUpgradeableReadLockHeld);
+		}
+	}
+}

--- a/CodeJam.Main/Threading/ReaderWriterLockSlimExtensions.cs
+++ b/CodeJam.Main/Threading/ReaderWriterLockSlimExtensions.cs
@@ -78,11 +78,8 @@ namespace CodeJam.Threading
 			/// </summary>
 			/// <param name="readerWriterLock">The <see cref="ReaderWriterLockSlim"/> instance.</param>
 			[DebuggerStepThrough]
-			internal ReadLockScope(ReaderWriterLockSlim readerWriterLock)
-			{
-				Code.NotNull(readerWriterLock, nameof(readerWriterLock));
+			internal ReadLockScope(ReaderWriterLockSlim readerWriterLock) =>
 				_readerWriterLock = readerWriterLock;
-			}
 
 			/// <summary>
 			/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
@@ -90,7 +87,7 @@ namespace CodeJam.Threading
 			[DebuggerStepThrough]
 			public void Dispose()
 			{
-				_readerWriterLock?.EnterReadLock();
+				_readerWriterLock?.ExitReadLock();
 				_readerWriterLock = null;
 			}
 		}
@@ -110,11 +107,8 @@ namespace CodeJam.Threading
 			/// </summary>
 			/// <param name="readerWriterLock">The <see cref="ReaderWriterLockSlim"/> instance.</param>
 			[DebuggerStepThrough]
-			internal WriteLockScope(ReaderWriterLockSlim readerWriterLock)
-			{
-				Code.NotNull(readerWriterLock, nameof(readerWriterLock));
+			internal WriteLockScope(ReaderWriterLockSlim readerWriterLock) =>
 				_readerWriterLock = readerWriterLock;
-			}
 
 			/// <summary>
 			/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
@@ -142,11 +136,8 @@ namespace CodeJam.Threading
 			/// </summary>
 			/// <param name="readerWriterLock">The <see cref="ReaderWriterLockSlim"/> instance.</param>
 			[DebuggerStepThrough]
-			public UpgradeableReadLockScope(ReaderWriterLockSlim readerWriterLock)
-			{
-				Code.NotNull(readerWriterLock, nameof(readerWriterLock));
+			public UpgradeableReadLockScope(ReaderWriterLockSlim readerWriterLock) =>
 				_readerWriterLock = readerWriterLock;
-			}
 
 			/// <summary>
 			/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.


### PR DESCRIPTION
* Resolved an issue where the incorrect method was being called - EnterReadLock instead of ExitReadLock.
* Added test cases.