### PR TITLE
Add overloads for custom disposable object creation method.

### DIFF
--- a/CodeJam.Main.Tests/DisposableExtensionsTests.cs
+++ b/CodeJam.Main.Tests/DisposableExtensionsTests.cs
@@ -61,7 +61,7 @@ public static class DisposableExtensionsTests
 
 #if NETSTANDARD21_OR_GREATER || NETCOREAPP30_OR_GREATER
 	[Test]
-	public static async Task DisposeAsyncMustCallDiposeOnce()
+	public static async Task DisposeAsyncMustCallDisposeOnce()
 	{
 		const int expectedDisposeCount = 1;
 


### PR DESCRIPTION
1. Added three new overloads for `Disposable.Create` extension method.
2.  Added relevant tests for `Disposable.Create` extension method overloads.
3. Fixed a typo in name of `DisposeAsyncMustCallDisposeOnce` test method.
4. Applied autoformatting for code in `DisposableTests` class.